### PR TITLE
Add `SignedPayload` struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,6 +34,15 @@ checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
 
 [[package]]
 name = "autocfg"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dde43e75fd43e8a1bf86103336bc699aa8d17ad1be60c76c0bdfd4828e19b78"
+dependencies = [
+ "autocfg 1.1.0",
+]
+
+[[package]]
+name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
@@ -86,6 +95,14 @@ dependencies = [
  "sha-1",
  "sha2",
  "thiserror",
+]
+
+[[package]]
+name = "bitcoinsuite-ecc-secp256k1"
+version = "0.1.0"
+dependencies = [
+ "bitcoinsuite-core",
+ "secp256k1-abc",
 ]
 
 [[package]]
@@ -147,8 +164,14 @@ dependencies = [
 name = "cashweb-payload"
 version = "0.1.0"
 dependencies = [
+ "bitcoinsuite-core",
+ "bitcoinsuite-ecc-secp256k1",
+ "bitcoinsuite-error",
+ "hex",
+ "pretty_assertions",
  "prost",
  "prost-build",
+ "thiserror",
 ]
 
 [[package]]
@@ -206,6 +229,15 @@ dependencies = [
  "glob",
  "libc",
  "libloading",
+]
+
+[[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -352,7 +384,7 @@ version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "hashbrown",
 ]
 
@@ -465,7 +497,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
- "autocfg",
+ "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -636,6 +668,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
+dependencies = [
+ "autocfg 0.1.8",
+ "libc",
+ "rand_chacha",
+ "rand_core 0.4.2",
+ "rand_hc",
+ "rand_isaac",
+ "rand_jitter",
+ "rand_os",
+ "rand_pcg",
+ "rand_xorshift",
+ "winapi",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
+dependencies = [
+ "autocfg 0.1.8",
+ "rand_core 0.3.1",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -649,6 +710,68 @@ name = "rand_core"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+
+[[package]]
+name = "rand_hc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_isaac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_jitter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
+dependencies = [
+ "libc",
+ "rand_core 0.4.2",
+ "winapi",
+]
+
+[[package]]
+name = "rand_os"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
+dependencies = [
+ "cloudabi",
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.4.2",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
+dependencies = [
+ "autocfg 0.1.8",
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
+dependencies = [
+ "rand_core 0.3.1",
+]
 
 [[package]]
 name = "rdrand"
@@ -724,6 +847,23 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "secp256k1-abc"
+version = "0.20.3"
+source = "git+https://github.com/raipay/secp256k1-abc#b23e74219f5c425eada0f53a52f9b51fdb3b23b2"
+dependencies = [
+ "rand 0.6.5",
+ "secp256k1-sys-abc",
+]
+
+[[package]]
+name = "secp256k1-sys-abc"
+version = "0.4.1"
+source = "git+https://github.com/raipay/secp256k1-abc#b23e74219f5c425eada0f53a52f9b51fdb3b23b2"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "secrecy"
@@ -814,7 +954,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 dependencies = [
- "rand",
+ "rand 0.4.6",
  "remove_dir_all",
 ]
 

--- a/cashweb-payload/Cargo.toml
+++ b/cashweb-payload/Cargo.toml
@@ -4,9 +4,24 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+bitcoinsuite-core = { path = "../../bitcoinsuite/bitcoinsuite-core" }
+bitcoinsuite-error = { path = "../../bitcoinsuite/bitcoinsuite-error" }
+
+# Hex en-/decoding
+hex = "0.4"
+
 # Protobuf (de)serialization
 prost = "0.10"
+
+# Derive error enums
+thiserror = "1.0"
 
 [build-dependencies]
 # Build Protobuf structs
 prost-build = "0.10"
+
+[dev-dependencies]
+bitcoinsuite-ecc-secp256k1 = { path = "../../bitcoinsuite/bitcoinsuite-ecc-secp256k1" }
+
+# assert_eq! and assert_ne! with colored diffs
+pretty_assertions = "1.0"

--- a/cashweb-payload/proto/payload.proto
+++ b/cashweb-payload/proto/payload.proto
@@ -5,9 +5,11 @@ package cashweb.payload;
 // providing a standard structure for covering a payload with a signature.
 message SignedPayload {
     // The public key associated with the signature.
-    bytes public_key = 1;
+    bytes pubkey = 1;
+
     // The signature (signed for public key) covering the payload.
-    bytes signature = 2;
+    bytes sig = 2;
+
     // Supported signature schemes. Default is Schnorr, but can be ECDSA.
     enum SignatureScheme {
         // Schnorr signature scheme.
@@ -15,15 +17,20 @@ message SignedPayload {
         // Elliptic curve digital signature scheme.
         ECDSA = 1;
     }
+
     // The signature scheme used for signing.
-    SignatureScheme scheme = 3;
+    SignatureScheme sig_scheme = 3;
+
     // The payload covered by the signature.
     bytes payload = 4;
-    // The SHA256 digest of the payload.
-    bytes payload_digest = 5;
+
+    // The SHA256 hash of the payload.
+    bytes payload_hash = 5;
+
     // Net amount of XPI burned in the transactions associated with this
     // signed payload.
     int64 burn_amount = 6;
+
     // Transactions which committed to the payload_digest.
     repeated BurnTx burn_txs = 7;
 }
@@ -38,5 +45,5 @@ message BurnTx {
 
     // Index of the OP_RETURN output in `tx` which contains the commitment for
     // the signed payload.
-    uint32 burn_index = 2;
+    uint32 burn_idx = 2;
 }

--- a/cashweb-payload/src/lib.rs
+++ b/cashweb-payload/src/lib.rs
@@ -1,4 +1,17 @@
+#![warn(
+    missing_debug_implementations,
+    missing_docs,
+    rust_2018_idioms,
+    unreachable_pub
+)]
+
+//! `cashweb-payload` is a library for verifying [`payload::SignedPayload`], and converting it to
+//! and from Protobuf.
+
+pub mod payload;
+pub mod verify;
+
 pub mod proto {
-    //! Protobuf structs for data stored by the registry.
+    //! Protobuf structs for SignedPayload.
     include!(concat!(env!("OUT_DIR"), "/cashweb.payload.rs"));
 }

--- a/cashweb-payload/src/payload.rs
+++ b/cashweb-payload/src/payload.rs
@@ -1,0 +1,476 @@
+//! Module for [`SignedPayload`] and [`BurnTx`].
+
+use bitcoinsuite_core::{
+    ecc::PUBKEY_LENGTH, BitcoinCode, Bytes, Hashed, Sha256, Tx, TxOutput, UnhashedTx,
+};
+use bitcoinsuite_error::{ErrorMeta, Result, WrapErr};
+use thiserror::Error;
+
+use crate::proto;
+pub use crate::proto::signed_payload::SignatureScheme;
+
+/// A payload signed with for a public key, which also provides a proof-of-burn to avoid spam.
+///
+/// SignedPayload provides integrity, authentication, and non-repuditation by
+/// providing a standard structure for covering a payload with a signature.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SignedPayload {
+    pub(crate) pubkey: [u8; PUBKEY_LENGTH],
+    pub(crate) sig: Bytes,
+    pub(crate) sig_scheme: SignatureScheme,
+    pub(crate) payload: Bytes,
+    pub(crate) payload_hash: Sha256,
+    pub(crate) burn_amount: i64,
+    pub(crate) burn_txs: Vec<BurnTx>,
+}
+
+/// A single burn transaction, commiting to a [`SignedPayload`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BurnTx {
+    pub(crate) tx: Tx,
+    pub(crate) burn_idx: u32,
+    pub(crate) burn_output: TxOutput,
+}
+
+/// Errors indicating that parsing a [`proto::SignedPayload`] failed.
+#[derive(Debug, Error, ErrorMeta, PartialEq, Eq)]
+pub enum ParseSignedPayloadError {
+    /// `pubkey` is not 33 bytes long.
+    #[invalid_client_input()]
+    #[error("Public key len should be {}, but got {0}", PUBKEY_LENGTH)]
+    InvalidPubKeyLen(usize),
+
+    /// Both `payload` and `payload_hash` are empty.
+    #[invalid_client_input()]
+    #[error("Both payload and payload hash are empty")]
+    PayloadHashAndPayloadEmpty,
+
+    /// `payload_hash` len is not 32 or empty.
+    #[invalid_client_input()]
+    #[error("Payload hash len should be 32 or empty, but got {0}")]
+    InvalidPayloadHashLen(usize),
+
+    /// Claimed `payload_hash` does not match actual hash of `payload`.
+    #[invalid_client_input()]
+    #[error("Payload hash does not match payload")]
+    IncorrectPayloadHash {
+        /// Expected hash claimed in the protobuf.
+        expected: Sha256,
+        /// Actual hash by hashing `payload` with SHA-256.
+        actual: Sha256,
+    },
+
+    /// Parsing `tx` in [`proto::BurnTx`] failed.
+    #[invalid_client_input()]
+    #[error("Parsing burn tx failed: {0}")]
+    ParsingBurnTxFailed(String),
+
+    /// Tx doesn't have `burn_idx` in [`proto::BurnTx`].
+    #[invalid_client_input()]
+    #[error("Burn tx doesn't have output index {0}")]
+    NoSuchOutput(usize),
+
+    /// `burn_amount` claimed in [`proto::SignedPayload`] doesn't match the actual burned amount.
+    #[invalid_client_input()]
+    #[error("Total burn amount mismatch: expected {expected}, but got {actual}")]
+    TotalBurnAmountMismatch {
+        /// Expected amount claimed in the protobuf.
+        expected: i64,
+        /// Actual sum of burned coins.
+        actual: i64,
+    },
+
+    /// Invalid `sig_scheme`, expected ECDSA or Schnorr.
+    #[invalid_client_input()]
+    #[error("Unknown signature scheme ID: {0}")]
+    UnknownSignatureScheme(i32),
+}
+
+use self::ParseSignedPayloadError::*;
+
+impl SignedPayload {
+    /// Parse and validate a [`proto::SignedPayload`].
+    ///
+    /// * `payload_hash` has to be empty or set to the hash of `payload`.
+    /// * `burn_txs` has to contain parsable txs.
+    /// * `burn_idx` has to point to an actually existing output in the tx.
+    /// * `burn_amount` has to be 0 or set to the sum of burned coins.
+    pub fn from_proto(signed_payload: proto::SignedPayload) -> Result<Self> {
+        let pubkey: [u8; PUBKEY_LENGTH] = signed_payload
+            .pubkey
+            .as_slice()
+            .try_into()
+            .map_err(|_| InvalidPubKeyLen(signed_payload.pubkey.len()))?;
+        let payload = Bytes::from(signed_payload.payload);
+        let expected_payload_hash = Sha256::digest(payload.clone());
+
+        // Assign or check the payload_hash
+        let payload_hash = match signed_payload.payload_hash.len() {
+            // If it's unset, set it to the expected hash
+            0 => {
+                if payload.is_empty() {
+                    return Err(PayloadHashAndPayloadEmpty.into());
+                }
+                expected_payload_hash
+            }
+            // If it's set, verify length and compare
+            _ => {
+                let actual_payload_hash = Sha256::from_slice(&signed_payload.payload_hash)
+                    .wrap_err(InvalidPayloadHashLen(signed_payload.payload_hash.len()))?;
+                if expected_payload_hash != actual_payload_hash {
+                    return Err(IncorrectPayloadHash {
+                        expected: expected_payload_hash,
+                        actual: actual_payload_hash,
+                    }
+                    .into());
+                }
+                expected_payload_hash
+            }
+        };
+
+        // Parse `BurnTx`s
+        let burn_txs = signed_payload
+            .burn_txs
+            .into_iter()
+            .map(|burn_tx| {
+                let tx = UnhashedTx::deser(&mut burn_tx.tx.clone().into())
+                    .wrap_err_with(|| ParsingBurnTxFailed(hex::encode(&burn_tx.tx)))?
+                    .hashed();
+                let burn_idx = burn_tx.burn_idx as usize;
+                let burn_output = tx
+                    .outputs()
+                    .get(burn_idx)
+                    .ok_or(NoSuchOutput(burn_idx))?
+                    .clone();
+                Ok(BurnTx {
+                    tx,
+                    burn_idx: burn_tx.burn_idx,
+                    burn_output,
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        // Calculate and verify the total burn amount
+        let actual_burn_amount = burn_txs
+            .iter()
+            .map(|burn_tx| burn_tx.burn_output.value)
+            .sum::<i64>();
+        if signed_payload.burn_amount > 0 && signed_payload.burn_amount != actual_burn_amount {
+            return Err(TotalBurnAmountMismatch {
+                expected: signed_payload.burn_amount,
+                actual: actual_burn_amount,
+            }
+            .into());
+        }
+
+        Ok(SignedPayload {
+            pubkey,
+            sig: signed_payload.sig.into(),
+            sig_scheme: SignatureScheme::from_i32(signed_payload.sig_scheme)
+                .ok_or(UnknownSignatureScheme(signed_payload.sig_scheme))?,
+            payload,
+            payload_hash,
+            burn_amount: actual_burn_amount,
+            burn_txs,
+        })
+    }
+
+    /// Converts the [`SignedPayload`] to a Protobuf [`proto::SignedPayload`].
+    pub fn to_proto(&self) -> proto::SignedPayload {
+        proto::SignedPayload {
+            pubkey: self.pubkey.to_vec(),
+            sig: self.sig.to_vec(),
+            sig_scheme: self.sig_scheme.into(),
+            payload: self.payload.to_vec(),
+            payload_hash: self.payload_hash.as_slice().to_vec(),
+            burn_amount: self.burn_amount,
+            burn_txs: self
+                .burn_txs
+                .iter()
+                .map(|burn_tx| proto::BurnTx {
+                    tx: burn_tx.tx.ser().to_vec(),
+                    burn_idx: burn_tx.burn_idx,
+                })
+                .collect(),
+        }
+    }
+
+    /// Public key signing for this payload.
+    pub fn pubkey(&self) -> &[u8; PUBKEY_LENGTH] {
+        &self.pubkey
+    }
+
+    /// Signature signing this payload.
+    pub fn sig(&self) -> &Bytes {
+        &self.sig
+    }
+
+    /// Signature scheme used by this `SignedPayload`, e.g. ECDSA or Schnorr
+    pub fn sig_scheme(&self) -> SignatureScheme {
+        self.sig_scheme
+    }
+
+    /// Payload that's being signed.
+    pub fn payload(&self) -> &Bytes {
+        &self.payload
+    }
+
+    /// Hash of `payload`.
+    pub fn payload_hash(&self) -> &Sha256 {
+        &self.payload_hash
+    }
+
+    /// Number of coins (in sats) being burned for this payload.
+    pub fn burn_amount(&self) -> i64 {
+        self.burn_amount
+    }
+
+    /// List of transactions burning coins for this payload.
+    pub fn txs(&self) -> &[BurnTx] {
+        &self.burn_txs
+    }
+}
+
+impl BurnTx {
+    /// Transaction burning coins for some payload.
+    pub fn tx(&self) -> &Tx {
+        &self.tx
+    }
+
+    /// Output index that burns the coins.
+    pub fn burn_idx(&self) -> u32 {
+        self.burn_idx
+    }
+
+    /// Output of `tx` that burns the coins.
+    pub fn burn_output(&self) -> &TxOutput {
+        &self.burn_output
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bitcoinsuite_core::{BitcoinCode, Bytes, Hashed, Script, Sha256, TxOutput, UnhashedTx};
+    use bitcoinsuite_error::Result;
+    use pretty_assertions::assert_eq;
+
+    use crate::{
+        payload::ParseSignedPayloadError,
+        payload::{BurnTx, SignatureScheme, SignedPayload},
+        proto,
+    };
+
+    #[test]
+    fn test_parse_signed_payload() -> Result<()> {
+        let payload_err = |payload_proto: proto::SignedPayload| -> Result<ParseSignedPayloadError> {
+            SignedPayload::from_proto(payload_proto)
+                .unwrap_err()
+                .downcast()
+        };
+        let pubkey = [2; 33];
+        let payload = Bytes::from([1, 2, 3, 4]);
+        let payload_hash = Sha256::digest(payload.clone());
+
+        let mut signed_payload = proto::SignedPayload::default();
+        assert_eq!(
+            payload_err(signed_payload.clone())?,
+            ParseSignedPayloadError::InvalidPubKeyLen(0),
+        );
+
+        // Set to valid pubkey, but payload and payload hash empty
+        signed_payload.pubkey = pubkey.to_vec();
+        assert_eq!(
+            payload_err(signed_payload.clone())?,
+            ParseSignedPayloadError::PayloadHashAndPayloadEmpty,
+        );
+
+        // With non-empty payload but empty payload_hash, we get the payload_hash prepared for us
+        signed_payload.payload = payload.to_vec();
+        assert_eq!(
+            SignedPayload::from_proto(signed_payload.clone())?,
+            SignedPayload {
+                pubkey,
+                sig: Bytes::new(),
+                sig_scheme: SignatureScheme::Schnorr,
+                payload: payload.clone(),
+                payload_hash: payload_hash.clone(),
+                burn_amount: 0,
+                burn_txs: vec![],
+            },
+        );
+
+        // Payload hash not 32 bytes (or empty)
+        signed_payload.payload_hash = vec![1, 2, 3];
+        assert_eq!(
+            payload_err(signed_payload.clone())?,
+            ParseSignedPayloadError::InvalidPayloadHashLen(3),
+        );
+
+        // Payload hash incorrect
+        signed_payload.payload_hash = vec![7; 32];
+        assert_eq!(
+            payload_err(signed_payload.clone())?,
+            ParseSignedPayloadError::IncorrectPayloadHash {
+                expected: payload_hash.clone(),
+                actual: Sha256::new([7; 32]),
+            },
+        );
+
+        {
+            // With correct payload_hash, we get the a valid SignedPayload
+            signed_payload.payload_hash = payload_hash.as_slice().to_vec();
+            let result = SignedPayload::from_proto(signed_payload.clone())?;
+            assert_eq!(
+                result,
+                SignedPayload {
+                    pubkey,
+                    sig: Bytes::new(),
+                    sig_scheme: SignatureScheme::Schnorr,
+                    payload: payload.clone(),
+                    payload_hash: payload_hash.clone(),
+                    burn_amount: 0,
+                    burn_txs: vec![],
+                },
+            );
+            // Check if going back to Protobuf works
+            assert_eq!(result.to_proto(), signed_payload);
+        }
+
+        // Tx fails to parse
+        signed_payload.burn_txs = vec![proto::BurnTx {
+            tx: b"invalid tx".to_vec(),
+            burn_idx: 0,
+        }];
+        assert_eq!(
+            payload_err(signed_payload.clone())?,
+            ParseSignedPayloadError::ParsingBurnTxFailed("696e76616c6964207478".to_string()),
+        );
+
+        // Tx parses, but the output burn_index points to doesn't exist
+        let tx = UnhashedTx {
+            version: 1,
+            inputs: vec![],
+            outputs: vec![TxOutput {
+                value: 1_000_000,
+                script: Script::default(),
+            }],
+            lock_time: 0,
+        };
+        signed_payload.burn_txs = vec![proto::BurnTx {
+            tx: tx.ser().to_vec(),
+            burn_idx: 10,
+        }];
+        assert_eq!(
+            payload_err(signed_payload.clone())?,
+            ParseSignedPayloadError::NoSuchOutput(10),
+        );
+
+        // If burn_amount is 0, it computes the burn_amount for us
+        signed_payload.burn_txs[0].burn_idx = 0;
+        assert_eq!(
+            SignedPayload::from_proto(signed_payload.clone())?,
+            SignedPayload {
+                pubkey,
+                sig: Bytes::new(),
+                sig_scheme: SignatureScheme::Schnorr,
+                payload: payload.clone(),
+                payload_hash: payload_hash.clone(),
+                burn_amount: 1_000_000,
+                burn_txs: vec![BurnTx {
+                    tx: tx.clone().hashed(),
+                    burn_output: tx.outputs[0].clone(),
+                    burn_idx: 0,
+                }],
+            },
+        );
+
+        // Otherwise, if burn_amount doesn't match exactly, it fails
+        signed_payload.burn_amount = 1234;
+        assert_eq!(
+            payload_err(signed_payload.clone())?,
+            ParseSignedPayloadError::TotalBurnAmountMismatch {
+                expected: 1234,
+                actual: 1_000_000,
+            },
+        );
+
+        // If set to the correct value, it works
+        signed_payload.burn_amount = 1_000_000;
+        assert_eq!(
+            SignedPayload::from_proto(signed_payload.clone())?,
+            SignedPayload {
+                pubkey,
+                sig: Bytes::new(),
+                sig_scheme: SignatureScheme::Schnorr,
+                payload: payload.clone(),
+                payload_hash: payload_hash.clone(),
+                burn_amount: 1_000_000,
+                burn_txs: vec![BurnTx {
+                    tx: tx.clone().hashed(),
+                    burn_output: tx.outputs[0].clone(),
+                    burn_idx: 0,
+                }],
+            },
+        );
+
+        // Adding second tx will make it mismatch again
+        signed_payload.burn_txs[0].tx = tx.ser().to_vec();
+        let tx2 = UnhashedTx {
+            version: 1,
+            inputs: vec![],
+            outputs: vec![
+                Default::default(),
+                Default::default(),
+                TxOutput {
+                    value: 234_567,
+                    script: Script::default(),
+                },
+            ],
+            lock_time: 0,
+        };
+        signed_payload.burn_txs.push(proto::BurnTx {
+            tx: tx2.ser().to_vec(),
+            burn_idx: 2,
+        });
+        assert_eq!(
+            payload_err(signed_payload.clone())?,
+            ParseSignedPayloadError::TotalBurnAmountMismatch {
+                expected: 1_000_000,
+                actual: 1_234_567,
+            },
+        );
+
+        {
+            // If we set the correct value, it works again
+            signed_payload.burn_amount = 1_234_567;
+            let result = SignedPayload::from_proto(signed_payload.clone())?;
+            assert_eq!(
+                result,
+                SignedPayload {
+                    pubkey,
+                    sig: Bytes::new(),
+                    sig_scheme: SignatureScheme::Schnorr,
+                    payload,
+                    payload_hash,
+                    burn_amount: 1_234_567,
+                    burn_txs: vec![
+                        BurnTx {
+                            tx: tx.clone().hashed(),
+                            burn_output: tx.outputs[0].clone(),
+                            burn_idx: 0,
+                        },
+                        BurnTx {
+                            tx: tx2.clone().hashed(),
+                            burn_output: tx2.outputs[2].clone(),
+                            burn_idx: 2,
+                        },
+                    ],
+                },
+            );
+            // Check if going back to Protobuf works
+            assert_eq!(result.to_proto(), signed_payload);
+        }
+
+        Ok(())
+    }
+}

--- a/cashweb-payload/src/verify.rs
+++ b/cashweb-payload/src/verify.rs
@@ -1,0 +1,448 @@
+//! Module for verifying a [`crate::payload::SignedPayload`] is valid.
+
+use bitcoinsuite_core::{
+    ecc::{Ecc, VerifySignatureError, PUBKEY_LENGTH},
+    Bytes, BytesMut, Hashed, Op, Script, Sha256,
+};
+use bitcoinsuite_error::{ErrorMeta, Result, WrapErr};
+use thiserror::Error;
+
+use crate::payload::{SignatureScheme, SignedPayload};
+
+/// LOKAD ID of commitment burns.
+pub const COMMITMENT_LOKAD_ID: [u8; 4] = *b"STMP";
+/// Opcode that indicates the version of the commitment.
+pub const COMMITMENT_VERSION_OPCODE: u8 = 0x51;
+/// Required length of the commitment.
+pub const COMMITMENT_LEN: u8 = 32;
+
+/// Error indicating why a [`crate::payload::SignedPayload`] is invalid.
+#[derive(Debug, Error, ErrorMeta, PartialEq, Eq)]
+pub enum ValidateSignedPayloadError {
+    /// Burn output is not OP_RETURN.
+    #[invalid_client_input()]
+    #[error("Burn tx output script is not OP_RETURN: {0}")]
+    BurnOutputNotOpReturn(String),
+
+    /// Parsing burn output script failed.
+    #[invalid_client_input()]
+    #[error("Parsing burn tx output script failed: {0}")]
+    ParsingBurnOutputScriptFailed(String),
+
+    /// Burn output has to have 4 ops.
+    #[invalid_client_input()]
+    #[error("Burn tx output expected 4 ops, but got {0} ops.")]
+    BurnOutputTooFewOps(usize),
+
+    /// LOKAD prefix is not STMP.
+    #[invalid_client_input()]
+    #[error(
+        "Burn tx output script expected LOKAD ID {:?} but got op {0:?}",
+        Bytes::from(COMMITMENT_LOKAD_ID)
+    )]
+    BurnOutputInvalidLokadId(Op),
+
+    /// Version opcode is not OP_1.
+    #[invalid_client_input()]
+    #[error(
+        "Burn tx output script expected version opcode {:02x} but got op {0:?}",
+        COMMITMENT_VERSION_OPCODE
+    )]
+    BurnOutputInvalidVersion(Op),
+
+    /// Burn output commitment is not 32 bytes long.
+    #[invalid_client_input()]
+    #[error(
+        "Burn tx output script expected commitment length {} but got op {0:?}",
+        COMMITMENT_LEN
+    )]
+    BurnOutputInvalidCommitmentLength(Op),
+
+    /// Burn output commitment is incorrect.
+    #[invalid_client_input()]
+    #[error("Burn tx {burn_tx_idx} commitment mismatch: expected {expected}, but got {actual}")]
+    BurnOutputCommitmentMismatch {
+        /// Expected commitment in the burn output.
+        expected: Sha256,
+        /// Actual commitment from the `pubkey` and `payload_hash`.
+        actual: Sha256,
+        /// Index of the invalid tx.
+        burn_tx_idx: usize,
+    },
+
+    /// `pubkey` is not valid.
+    #[invalid_client_input()]
+    #[error("Invalid secp256k1 pubkey: {0}")]
+    InvalidPubKey(String),
+
+    /// `sig` is not a valid/correct Schnorr signature.
+    #[invalid_client_input()]
+    #[error("Invalid payload Schnorr signature: {0}")]
+    InvalidSchnorrSignature(VerifySignatureError),
+
+    /// `sig` is not a valid/correct ECDSA signature.
+    #[invalid_client_input()]
+    #[error("Invalid payload ECDSA signature: {0}")]
+    InvalidEcdsaSignature(VerifySignatureError),
+}
+
+use self::ValidateSignedPayloadError::*;
+
+impl SignedPayload {
+    /// Validates that the [`proto::SignedPayload`] burns the claimed amount to the corrent commitments.
+    ///
+    /// Burn output script must look like this:
+    /// `OP_RETURN <lokad_id: STMP> <version: 1> <commitment: 32 bytes>`
+    pub fn verify(&self, ecc: &impl Ecc) -> Result<()> {
+        // Verify OP_RETURN commitments
+        let expected_commitment = calc_commitment(self.pubkey, &self.payload_hash);
+        for (idx, burn_tx) in self.burn_txs.iter().enumerate() {
+            let parsed_commitment = parse_commitment(&burn_tx.burn_output.script)?;
+            if expected_commitment != parsed_commitment {
+                return Err(BurnOutputCommitmentMismatch {
+                    expected: expected_commitment,
+                    actual: parsed_commitment,
+                    burn_tx_idx: idx,
+                }
+                .into());
+            }
+        }
+
+        // Verify signature signs payload hash
+        let pubkey = ecc
+            .pubkey_from_array(self.pubkey)
+            .wrap_err_with(|| InvalidPubKey(hex::encode(&self.pubkey)))?;
+        let msg = self.payload_hash.byte_array().clone();
+        match self.sig_scheme {
+            SignatureScheme::Schnorr => ecc
+                .schnorr_verify(&pubkey, msg, &self.sig)
+                .map_err(InvalidSchnorrSignature)?,
+            SignatureScheme::Ecdsa => ecc
+                .verify(&pubkey, msg, &self.sig)
+                .map_err(InvalidEcdsaSignature)?,
+        }
+
+        Ok(())
+    }
+}
+
+fn parse_commitment(script: &Script) -> Result<Sha256> {
+    // Must be OP_RETURN
+    if !script.is_opreturn() {
+        return Err(BurnOutputNotOpReturn(script.hex()).into());
+    }
+    let script_ops = script
+        .ops()
+        .map(|op| op.map_err(Into::into))
+        .collect::<Result<Vec<_>>>()
+        .wrap_err_with(|| ParsingBurnOutputScriptFailed(script.hex()))?;
+
+    // OP_RETURN <lokad_id: STMP> <version: 1> <commitment: 32 bytes>
+    if script_ops.len() != 4 {
+        return Err(BurnOutputTooFewOps(script_ops.len()).into());
+    }
+
+    // Check LOKAD ID
+    if script_ops[1] != Op::Push(4, COMMITMENT_LOKAD_ID.into()) {
+        return Err(BurnOutputInvalidLokadId(script_ops[1].clone()).into());
+    }
+
+    // Check version (must be OP_1)
+    if script_ops[2] != Op::Code(COMMITMENT_VERSION_OPCODE) {
+        return Err(BurnOutputInvalidVersion(script_ops[2].clone()).into());
+    }
+
+    // Extract commitment
+    let commitment = match &script_ops[3] {
+        Op::Push(COMMITMENT_LEN, commitment) => commitment,
+        _ => return Err(BurnOutputInvalidCommitmentLength(script_ops[3].clone()).into()),
+    };
+
+    Ok(Sha256::new(commitment.as_ref().try_into().unwrap()))
+}
+
+fn calc_commitment(pubkey_raw: [u8; PUBKEY_LENGTH], payload_hash: &Sha256) -> Sha256 {
+    let pubkey_hash = Sha256::digest(pubkey_raw.into());
+    let mut commitment_preimage = BytesMut::new();
+    commitment_preimage.put_byte_array(pubkey_hash.byte_array().clone());
+    commitment_preimage.put_byte_array(payload_hash.byte_array().clone());
+    Sha256::digest(commitment_preimage.freeze())
+}
+
+#[cfg(test)]
+mod tests {
+    use bitcoinsuite_core::{
+        ecc::{Ecc, VerifySignatureError, PUBKEY_LENGTH},
+        ByteArray, Bytes, Hashed, Op, Script, Sha256, TxOutput, UnhashedTx,
+    };
+    use bitcoinsuite_ecc_secp256k1::EccSecp256k1;
+    use bitcoinsuite_error::Result;
+    use pretty_assertions::assert_eq;
+
+    use crate::{
+        payload::{BurnTx, SignatureScheme, SignedPayload},
+        verify::{
+            calc_commitment,
+            ValidateSignedPayloadError::{self, *},
+        },
+    };
+
+    #[test]
+    fn test_verify_signed_payload() -> Result<()> {
+        let ecc = EccSecp256k1::default();
+        let verify_err = |payload: &SignedPayload| -> Result<ValidateSignedPayloadError> {
+            payload.verify(&ecc).unwrap_err().downcast()
+        };
+        let payload = Bytes::from([1, 2, 3, 4]);
+        let payload_hash = Sha256::digest(payload.clone());
+        let pubkey = [0x77; PUBKEY_LENGTH];
+        let commitment_hash = Sha256::digest(
+            [
+                Sha256::digest(pubkey.as_slice().into()).as_slice(),
+                payload_hash.as_slice(),
+            ]
+            .concat()
+            .into(),
+        );
+        let commitment_hash_raw = Bytes::from_slice(commitment_hash.as_slice());
+        let commitment_script = Script::from_ops(
+            vec![
+                Op::Code(0x6a),
+                Op::Push(4, Bytes::from(*b"STMP")),
+                Op::Code(0x51),
+                Op::Push(32, commitment_hash_raw),
+            ]
+            .into_iter(),
+        )?;
+
+        let mut signed_payload = SignedPayload {
+            pubkey,
+            sig: Bytes::new(),
+            sig_scheme: SignatureScheme::Schnorr,
+            payload,
+            payload_hash: payload_hash.clone(),
+            burn_amount: 0,
+            burn_txs: vec![],
+        };
+
+        let tx = UnhashedTx {
+            version: 1,
+            inputs: vec![],
+            outputs: vec![TxOutput {
+                value: 0,
+                script: Script::default(),
+            }],
+            lock_time: 0,
+        };
+
+        // Burn output not OP_RETURN
+        signed_payload.burn_txs = vec![BurnTx {
+            tx: tx.clone().hashed(),
+            burn_idx: 0,
+            burn_output: tx.outputs[0].clone(),
+        }];
+        assert_eq!(
+            verify_err(&signed_payload)?,
+            BurnOutputNotOpReturn("".to_string()),
+        );
+
+        // Burn script fails to parse
+        signed_payload.burn_txs[0].burn_output.script = Script::from_hex("6a0f")?;
+        assert_eq!(
+            verify_err(&signed_payload)?,
+            ParsingBurnOutputScriptFailed("6a0f".to_string()),
+        );
+
+        // Too few ops, expected 4 but got 2
+        signed_payload.burn_txs[0].burn_output.script = Script::from_hex("6a00")?;
+        assert_eq!(verify_err(&signed_payload)?, BurnOutputTooFewOps(2),);
+
+        // Invalid LOKAD ID, should be STMP
+        signed_payload.burn_txs[0].burn_output.script = Script::from_hex("6a515253")?;
+        assert_eq!(
+            verify_err(&signed_payload)?,
+            BurnOutputInvalidLokadId(Op::Code(0x51)),
+        );
+
+        // Invalid version, should be OP_1
+        signed_payload.burn_txs[0].burn_output.script = Script::from_ops(
+            vec![
+                Op::Code(0x6a),
+                Op::Push(4, Bytes::from(*b"STMP")),
+                Op::Code(0x52),
+                Op::Code(0x53),
+            ]
+            .into_iter(),
+        )?;
+        assert_eq!(
+            verify_err(&signed_payload)?,
+            BurnOutputInvalidVersion(Op::Code(0x52)),
+        );
+
+        // Invalid commitment length, must be 32
+        signed_payload.burn_txs[0].burn_output.script = Script::from_ops(
+            vec![
+                Op::Code(0x6a),
+                Op::Push(4, Bytes::from(*b"STMP")),
+                Op::Code(0x51),
+                Op::Code(0x53),
+            ]
+            .into_iter(),
+        )?;
+        assert_eq!(
+            verify_err(&signed_payload)?,
+            BurnOutputInvalidCommitmentLength(Op::Code(0x53)),
+        );
+
+        // Invalid commitment
+        signed_payload.burn_txs[0].burn_output.script = Script::from_ops(
+            vec![
+                Op::Code(0x6a),
+                Op::Push(4, Bytes::from(*b"STMP")),
+                Op::Code(0x51),
+                Op::Push(32, vec![4; 32].into()),
+            ]
+            .into_iter(),
+        )?;
+        assert_eq!(
+            verify_err(&signed_payload)?,
+            BurnOutputCommitmentMismatch {
+                expected: commitment_hash.clone(),
+                actual: Sha256::new([4; 32]),
+                burn_tx_idx: 0,
+            },
+        );
+
+        // First commitment valid, second invalid
+        signed_payload.burn_txs[0].burn_output.script = commitment_script.clone();
+        let tx2 = UnhashedTx {
+            version: 1,
+            inputs: vec![],
+            outputs: vec![
+                Default::default(),
+                Default::default(),
+                TxOutput {
+                    value: 234_567,
+                    script: Script::from_ops(
+                        vec![
+                            Op::Code(0x6a),
+                            Op::Push(4, Bytes::from(*b"STMP")),
+                            Op::Code(0x51),
+                            Op::Push(32, vec![5; 32].into()),
+                        ]
+                        .into_iter(),
+                    )?,
+                },
+            ],
+            lock_time: 0,
+        };
+        signed_payload.burn_txs.push(BurnTx {
+            burn_output: tx2.outputs[2].clone(),
+            tx: tx2.hashed(),
+            burn_idx: 2,
+        });
+        assert_eq!(
+            verify_err(&signed_payload)?,
+            BurnOutputCommitmentMismatch {
+                expected: commitment_hash,
+                actual: Sha256::new([5; 32]),
+                burn_tx_idx: 1,
+            },
+        );
+
+        // Fix the commitment, pubkey invalid now
+        signed_payload.burn_txs[1].burn_output.script = commitment_script;
+        assert_eq!(
+            verify_err(&signed_payload)?,
+            InvalidPubKey(
+                "777777777777777777777777777777777777777777777777777777777777777777".to_string()
+            ),
+        );
+
+        // Fix pubkey (and commitment)
+        let seckey = ecc.seckey_from_array([0x44; 32])?;
+        let pubkey = ecc.derive_pubkey(&seckey).array();
+        let commitment_hash = calc_commitment(pubkey, &payload_hash);
+        let commitment_hash_raw = Bytes::from_slice(commitment_hash.as_slice());
+        let commitment_script = Script::from_ops(
+            vec![
+                Op::Code(0x6a),
+                Op::Push(4, Bytes::from(*b"STMP")),
+                Op::Code(0x51),
+                Op::Push(32, commitment_hash_raw),
+            ]
+            .into_iter(),
+        )?;
+        signed_payload.pubkey = pubkey;
+        signed_payload.burn_txs[0].burn_output.script = commitment_script.clone();
+        signed_payload.burn_txs[1].burn_output.script = commitment_script;
+        // Now, Schnorr signature is invalid format (is empty)
+        assert_eq!(
+            verify_err(&signed_payload)?,
+            InvalidSchnorrSignature(VerifySignatureError::InvalidFormat),
+        );
+
+        // Same for ECDSA
+        signed_payload.sig_scheme = SignatureScheme::Ecdsa;
+        assert_eq!(
+            verify_err(&signed_payload)?,
+            InvalidEcdsaSignature(VerifySignatureError::InvalidFormat),
+        );
+
+        // Valid Schnorr format (64 bytes), but incorrect signature
+        signed_payload.sig_scheme = SignatureScheme::Schnorr;
+        signed_payload.sig = Bytes::from([0x88; 64]);
+        assert_eq!(
+            verify_err(&signed_payload)?,
+            InvalidSchnorrSignature(VerifySignatureError::IncorrectSignature),
+        );
+
+        // Valid Schnorr format (64 bytes), but signing incorrect data
+        signed_payload.sig = ecc.schnorr_sign(&seckey, ByteArray::new([54; 32]));
+        assert_eq!(
+            verify_err(&signed_payload)?,
+            InvalidSchnorrSignature(VerifySignatureError::IncorrectSignature),
+        );
+
+        // Valid ECDSA format, but signing incorrect data
+        signed_payload.sig_scheme = SignatureScheme::Ecdsa;
+        signed_payload.sig = ecc.sign(&seckey, ByteArray::new([54; 32]));
+        assert_eq!(
+            verify_err(&signed_payload)?,
+            InvalidEcdsaSignature(VerifySignatureError::IncorrectSignature),
+        );
+
+        // Correct signatures
+        let ecdsa_sig = ecc.sign(&seckey, signed_payload.payload_hash.byte_array().clone());
+        let schnorr_sig =
+            ecc.schnorr_sign(&seckey, signed_payload.payload_hash.byte_array().clone());
+
+        // Provide ECDSA sig but Schorr requested
+        signed_payload.sig_scheme = SignatureScheme::Schnorr;
+        signed_payload.sig = ecdsa_sig.clone();
+        assert_eq!(
+            verify_err(&signed_payload)?,
+            InvalidSchnorrSignature(VerifySignatureError::InvalidFormat),
+        );
+
+        // Provide Schnorr sig but ECDSA requested
+        signed_payload.sig_scheme = SignatureScheme::Ecdsa;
+        signed_payload.sig = schnorr_sig.clone();
+        assert_eq!(
+            verify_err(&signed_payload)?,
+            InvalidEcdsaSignature(VerifySignatureError::InvalidFormat),
+        );
+
+        // Correct sig: Schnorr
+        signed_payload.sig_scheme = SignatureScheme::Schnorr;
+        signed_payload.sig = schnorr_sig;
+        signed_payload.verify(&ecc)?;
+
+        // Correct sig: ECDSA
+        signed_payload.sig_scheme = SignatureScheme::Ecdsa;
+        signed_payload.sig = ecdsa_sig;
+        signed_payload.verify(&ecc)?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This represents a parsed variant of `proto::SignedPayload`, parsing txs and validating hashes/amounts check out.