### PR TITLE
Add HTTP endpoint for CashWeb registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "axum"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47594e438a243791dba58124b6669561f5baa14cb12046641d8008bf035e5a25"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "base64",
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sha-1 0.10.0",
+ "sync_wrapper",
+ "tokio",
+ "tokio-tungstenite 0.17.1",
+ "tower",
+ "tower-http",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a671c9ae99531afdd5d3ee8340b8da547779430689947144c140fc74a740244"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -167,6 +215,7 @@ dependencies = [
 name = "bitcoinsuite-core"
 version = "0.1.0"
 dependencies = [
+ "bs58",
  "bytes",
  "digest 0.9.0",
  "hex",
@@ -268,6 +317,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
+
+[[package]]
 name = "buf_redux"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,6 +365,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "cashweb-http-utils"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "axum",
+ "bitcoinsuite-error",
+ "hyper",
+ "prost 0.10.0",
+ "prost-build 0.10.0",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "cashweb-payload"
 version = "0.1.0"
 dependencies = [
@@ -327,18 +396,21 @@ dependencies = [
 name = "cashweb-registry"
 version = "0.1.0"
 dependencies = [
+ "axum",
  "bitcoinsuite-bitcoind",
  "bitcoinsuite-core",
  "bitcoinsuite-ecc-secp256k1",
  "bitcoinsuite-error",
  "bitcoinsuite-test-utils",
  "bitcoinsuite-test-utils-blockchain",
+ "cashweb-http-utils",
  "cashweb-payload",
  "hex",
  "json",
  "pretty_assertions",
  "prost 0.10.0",
  "prost-build 0.10.0",
+ "reqwest",
  "rocksdb",
  "tempdir",
  "thiserror",
@@ -789,6 +861,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
+
+[[package]]
 name = "httparse"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1008,6 +1086,12 @@ name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
+
+[[package]]
+name = "matchit"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
 
 [[package]]
 name = "memchr"
@@ -1967,6 +2051,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
+
+[[package]]
 name = "tempdir"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2108,7 +2198,19 @@ dependencies = [
  "log",
  "pin-project",
  "tokio",
- "tungstenite",
+ "tungstenite 0.14.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06cda1232a49558c46f8a504d5b93101d42c0bf7f911f12a105ba48168f821ae"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.17.2",
 ]
 
 [[package]]
@@ -2204,6 +2306,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-http"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aba3f3efabf7fb41fae8534fc20a817013dd1c12cb45441efb6c82e6556b4cd8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-range-header",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2278,6 +2399,25 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "sha-1 0.9.8",
+ "thiserror",
+ "url",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96a2dea40e7570482f28eb57afbe42d97551905da6a9400acc5c328d24004f5"
+dependencies = [
+ "base64",
+ "byteorder",
+ "bytes",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha-1 0.10.0",
  "thiserror",
  "url",
  "utf-8",
@@ -2404,7 +2544,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.15.0",
  "tokio-util 0.6.9",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 
 members = [
+    "cashweb-http-utils",
     "cashweb-payload",
     "cashweb-registry",
     "cashwebd-exe",

--- a/cashweb-http-utils/Cargo.toml
+++ b/cashweb-http-utils/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "cashweb-http-utils"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+bitcoinsuite-error = { path = "../../bitcoinsuite/bitcoinsuite-error" }
+
+# #[async_trait] macro
+async-trait = "0.1.50"
+
+# Web app framework
+axum = { version = "0.5", features = ["ws"] }
+
+# HTTP implementation
+hyper = "0.14"
+
+# Protobuf (de)serialization
+prost = "0.10"
+
+# Async runtime
+tokio = { version = "1.17", features = ["full"] }
+
+# Derive error enums
+thiserror = "1.0"
+
+[build-dependencies]
+# Build Protobuf structs
+prost-build = "0.10"

--- a/cashweb-http-utils/build.rs
+++ b/cashweb-http-utils/build.rs
@@ -1,0 +1,6 @@
+use std::io::Result;
+
+fn main() -> Result<()> {
+    prost_build::compile_protos(&["proto/http.proto"], &["proto/"])?;
+    Ok(())
+}

--- a/cashweb-http-utils/proto/http.proto
+++ b/cashweb-http-utils/proto/http.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package cashweb.http;
+
+// Error report when something went wrong on the backend
+message Error {
+    // Error code in kebab case, e.g. "invalid-address"
+    string error_code = 1;
+    // Human-readable message detailling the error.
+    string msg = 2;
+    // Whether this error is likely originating from a user.
+    // In this case, apps can display `msg` to the user.
+    bool is_user_error = 3;
+}

--- a/cashweb-http-utils/src/error.rs
+++ b/cashweb-http-utils/src/error.rs
@@ -1,0 +1,95 @@
+//! Module containing tools for mapping [`Report`]s to HTTP errors.
+
+use axum::response::{IntoResponse, Response};
+use bitcoinsuite_error::{report_to_details, ErrorDetails, ErrorMeta, ErrorSeverity, Report};
+use hyper::StatusCode;
+
+use crate::{
+    proto,
+    protobuf::{CashwebProtobufError, Protobuf},
+    validation::CashwebValidationError,
+};
+
+/// Error newtype for [`Report`], for errors of this crate.
+/// Implements [`IntoResponse`].
+#[derive(Debug)]
+pub struct HttpUtilError(pub Report);
+
+impl From<Report> for HttpUtilError {
+    fn from(err: Report) -> Self {
+        HttpUtilError(err)
+    }
+}
+
+impl From<CashwebProtobufError> for HttpUtilError {
+    fn from(err: CashwebProtobufError) -> Self {
+        HttpUtilError(err.into())
+    }
+}
+
+impl IntoResponse for HttpUtilError {
+    fn into_response(self) -> Response {
+        let details = report_to_details(&self.0, self::report_to_error_meta);
+        details_to_status_proto(details).into_response()
+    }
+}
+
+/// Map the [`ErrorDetails`] to a [`StatusCode`] and [`proto::Error`] instance.
+/// Status is based on the [`ErrorSeverity`] of `details`.
+pub fn details_to_status_proto(details: ErrorDetails) -> (StatusCode, Protobuf<proto::Error>) {
+    match details.severity {
+        ErrorSeverity::NotFound => (
+            StatusCode::NOT_FOUND,
+            Protobuf(proto::Error {
+                error_code: details.error_code.to_string(),
+                msg: details.msg,
+                is_user_error: true,
+            }),
+        ),
+        ErrorSeverity::InvalidUserInput => (
+            StatusCode::BAD_REQUEST,
+            Protobuf(proto::Error {
+                error_code: details.error_code.to_string(),
+                msg: details.msg,
+                is_user_error: true,
+            }),
+        ),
+        ErrorSeverity::InvalidClientInput => {
+            println!("Invalid client input: {}", details.msg);
+            (
+                StatusCode::BAD_REQUEST,
+                Protobuf(proto::Error {
+                    error_code: details.error_code.to_string(),
+                    msg: details.msg,
+                    is_user_error: false,
+                }),
+            )
+        }
+        ErrorSeverity::Critical
+        | ErrorSeverity::Unknown
+        | ErrorSeverity::Bug
+        | ErrorSeverity::Warning => {
+            println!("Unhandled error ({:?}):", details.severity);
+            println!("{}", details.full_debug_report);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Protobuf(proto::Error {
+                    error_code: "internal-server-error".into(),
+                    msg: "Internal server error".to_string(),
+                    is_user_error: false,
+                }),
+            )
+        }
+    }
+}
+
+/// Maps errors occuring in this crate to an [`ErrorMeta`] trait object.
+pub fn report_to_error_meta(report: &Report) -> Option<&dyn ErrorMeta> {
+    if let Some(err) = report.downcast_ref::<CashwebProtobufError>() {
+        Some(err)
+    } else if let Some(err) = report.downcast_ref::<CashwebValidationError>() {
+        Some(err)
+    } else {
+        None
+    }
+}

--- a/cashweb-http-utils/src/lib.rs
+++ b/cashweb-http-utils/src/lib.rs
@@ -1,0 +1,17 @@
+#![warn(
+    missing_debug_implementations,
+    missing_docs,
+    rust_2018_idioms,
+    unreachable_pub
+)]
+
+//! `cashweb-http-utils` is a crate providing utils for CashWeb HTTP servers.
+
+pub mod error;
+pub mod protobuf;
+pub mod validation;
+
+pub mod proto {
+    //! Protobuf structs for SignedPayload.
+    include!(concat!(env!("OUT_DIR"), "/cashweb.http.rs"));
+}

--- a/cashweb-http-utils/src/protobuf.rs
+++ b/cashweb-http-utils/src/protobuf.rs
@@ -1,0 +1,67 @@
+//! Module containing [`Protobuf`] [`axum`] extractor, allowing convenient en/-decoding of Protobuf
+//! request/response bodies.
+
+use async_trait::async_trait;
+use axum::{
+    extract::{FromRequest, RequestParts},
+    http::HeaderValue,
+    response::{IntoResponse, Response},
+};
+use bitcoinsuite_error::ErrorMeta;
+use hyper::{body::to_bytes, header::CONTENT_TYPE, Body};
+use prost::Message;
+use thiserror::Error;
+
+use crate::{error::HttpUtilError, validation::check_content_type};
+
+/// Newtype around a Protobuf [`Message`], allows [`axum`] to en-/decode this Protobuf message.
+#[derive(Debug)]
+pub struct Protobuf<P: Message + Default>(pub P);
+
+/// HTTP "Content-Type" for protobuf payloads.
+pub const CONTENT_TYPE_PROTOBUF: &str = "application/x-protobuf";
+
+/// Error indicating that [`FromRequest`] for a Protobuf message failed.
+#[derive(Debug, Error, ErrorMeta)]
+pub enum CashwebProtobufError {
+    /// Cannot convert request body to bytes.
+    #[invalid_client_input()]
+    #[error("Invalid body: {0}")]
+    InvalidBody(String),
+
+    /// Body doesn't encode expected Protobuf.
+    #[invalid_client_input()]
+    #[error("Bad protobuf: {0}")]
+    BadProtobuf(String),
+}
+
+use self::CashwebProtobufError::*;
+
+#[async_trait]
+impl<P: Message + Default> FromRequest<Body> for Protobuf<P> {
+    type Rejection = HttpUtilError;
+
+    async fn from_request(req: &mut RequestParts<Body>) -> Result<Self, Self::Rejection> {
+        let headers = req.headers();
+        check_content_type(headers, CONTENT_TYPE_PROTOBUF)?;
+        let mut body = req.take_body().expect("Body taken");
+        let mut body_bytes = to_bytes(&mut body)
+            .await
+            .map_err(|err| InvalidBody(err.to_string()))?;
+        let proto = P::decode(&mut body_bytes).map_err(|err| BadProtobuf(err.to_string()))?;
+        Ok(Protobuf(proto))
+    }
+}
+
+impl<P: Message + Default> IntoResponse for Protobuf<P> {
+    fn into_response(self) -> Response {
+        let mut response = Response::builder()
+            .body(axum::body::boxed(Body::from(self.0.encode_to_vec())))
+            .unwrap();
+        response.headers_mut().insert(
+            CONTENT_TYPE,
+            HeaderValue::from_static(CONTENT_TYPE_PROTOBUF),
+        );
+        response
+    }
+}

--- a/cashweb-http-utils/src/validation.rs
+++ b/cashweb-http-utils/src/validation.rs
@@ -1,0 +1,49 @@
+//! Module validating HTTP requests.
+
+use hyper::{header::CONTENT_TYPE, HeaderMap};
+
+use bitcoinsuite_error::{ErrorMeta, Report};
+
+use thiserror::Error;
+
+/// HTTP request validation error.
+#[derive(Debug, Error, ErrorMeta)]
+pub enum CashwebValidationError {
+    /// HTTP "Content-Type" header was not set.
+    #[invalid_client_input()]
+    #[error("No Content-Type set")]
+    NoContentTypeSet,
+
+    /// "Content-Type" header has bad encoding.
+    #[invalid_client_input()]
+    #[error("Content-Type bad encoding: {0}")]
+    BadContentType(String),
+
+    /// "Content-Type" header expected to be specific value.
+    #[invalid_client_input()]
+    #[error("Content-Type must be {expected}, got {actual}")]
+    WrongContentType {
+        /// Content-Type expected by the handler.
+        expected: &'static str,
+        /// Content-Type provided by the request.
+        actual: String,
+    },
+}
+
+use self::CashwebValidationError::*;
+
+/// Validate the "Content-Type" header matches `expected`.
+pub fn check_content_type(headers: &HeaderMap, expected: &'static str) -> Result<(), Report> {
+    let content_type = headers.get(CONTENT_TYPE).ok_or(NoContentTypeSet)?;
+    let content_type = content_type
+        .to_str()
+        .map_err(|err| BadContentType(err.to_string()))?;
+    if content_type != expected {
+        return Err(WrongContentType {
+            expected,
+            actual: content_type.to_string(),
+        }
+        .into());
+    }
+    Ok(())
+}

--- a/cashweb-payload/src/error.rs
+++ b/cashweb-payload/src/error.rs
@@ -1,0 +1,16 @@
+//! Module containing [`report_to_error_meta`] to map errors of this crate to [`ErrorMeta`].
+
+use bitcoinsuite_error::{ErrorMeta, Report};
+
+use crate::{payload::ParseSignedPayloadError, verify::ValidateSignedPayloadError};
+
+/// Maps errors occuring in this crate to an [`ErrorMeta`] trait object.
+pub fn report_to_error_meta(report: &Report) -> Option<&dyn ErrorMeta> {
+    if let Some(err) = report.downcast_ref::<ParseSignedPayloadError>() {
+        Some(err)
+    } else if let Some(err) = report.downcast_ref::<ValidateSignedPayloadError>() {
+        Some(err)
+    } else {
+        None
+    }
+}

--- a/cashweb-payload/src/lib.rs
+++ b/cashweb-payload/src/lib.rs
@@ -8,6 +8,7 @@
 //! `cashweb-payload` is a library for verifying [`payload::SignedPayload`], and converting it to
 //! and from Protobuf.
 
+pub mod error;
 pub mod payload;
 pub mod verify;
 

--- a/cashweb-registry/Cargo.toml
+++ b/cashweb-registry/Cargo.toml
@@ -7,8 +7,13 @@ edition = "2021"
 bitcoinsuite-core = { path = "../../bitcoinsuite/bitcoinsuite-core" }
 bitcoinsuite-bitcoind = { path = "../../bitcoinsuite/bitcoinsuite-bitcoind" }
 bitcoinsuite-error = { path = "../../bitcoinsuite/bitcoinsuite-error" }
+bitcoinsuite-ecc-secp256k1 = { path = "../../bitcoinsuite/bitcoinsuite-ecc-secp256k1" }
 
+cashweb-http-utils = { path = "../cashweb-http-utils" }
 cashweb-payload = { path = "../cashweb-payload" }
+
+# Web app framework
+axum = { version = "0.5", features = ["ws"] }
 
 # Build JSON objects
 json = "0.12"
@@ -39,6 +44,9 @@ bitcoinsuite-test-utils-blockchain = { path = "../../bitcoinsuite/bitcoinsuite-t
 
 # assert_eq! and assert_ne! with colored diffs
 pretty_assertions = "1.2"
+
+# Simple HTTP client (for testing)
+reqwest = "0.11"
 
 # Temporary directories, automatically removed
 tempdir = "0.3"

--- a/cashweb-registry/proto/registry.proto
+++ b/cashweb-registry/proto/registry.proto
@@ -37,3 +37,9 @@ message Peers {
     // A list of peers.
     repeated Peer peers = 1;
 }
+
+// Response after putting address metadata to the registry.
+message PutAddressMetadataResponse {
+    // Transaction IDs of the burn txs.
+    repeated bytes txid = 1;
+}

--- a/cashweb-registry/src/http/error.rs
+++ b/cashweb-registry/src/http/error.rs
@@ -1,0 +1,48 @@
+//! Module containing [`HttpRegistryError`], an error newtype and [`report_to_error_meta`] to map
+//! errors of this crate to [`ErrorMeta`].
+
+use axum::response::{IntoResponse, Response};
+use bitcoinsuite_error::{report_to_details, ErrorMeta, Report};
+use cashweb_http_utils::error::details_to_status_proto;
+
+use crate::{
+    http::server::RegistryServerError, registry::RegistryError, store::pubkeyhash::PkhError,
+};
+
+/// Newtype around [`Report`], implements [`IntoResponse`].
+#[derive(Debug)]
+pub struct HttpRegistryError(pub Report);
+
+impl From<Report> for HttpRegistryError {
+    fn from(err: Report) -> Self {
+        HttpRegistryError(err)
+    }
+}
+
+impl From<RegistryServerError> for HttpRegistryError {
+    fn from(err: RegistryServerError) -> Self {
+        HttpRegistryError(err.into())
+    }
+}
+
+impl IntoResponse for HttpRegistryError {
+    fn into_response(self) -> Response {
+        let details = report_to_details(&self.0, self::report_to_error_meta);
+        details_to_status_proto(details).into_response()
+    }
+}
+
+/// Maps errors occuring in this crate to an [`ErrorMeta`] trait object.
+pub fn report_to_error_meta(report: &Report) -> Option<&dyn ErrorMeta> {
+    if let Some(err) = report.downcast_ref::<RegistryServerError>() {
+        Some(err)
+    } else if let Some(err) = report.downcast_ref::<RegistryError>() {
+        Some(err)
+    } else if let Some(err) = report.downcast_ref::<PkhError>() {
+        Some(err)
+    } else if let Some(err) = cashweb_payload::error::report_to_error_meta(report) {
+        Some(err)
+    } else {
+        None
+    }
+}

--- a/cashweb-registry/src/http/mod.rs
+++ b/cashweb-registry/src/http/mod.rs
@@ -1,0 +1,4 @@
+//! Modules for an HTTP endpoint for the Cashweb Registry.
+
+pub mod error;
+pub mod server;

--- a/cashweb-registry/src/http/server.rs
+++ b/cashweb-registry/src/http/server.rs
@@ -1,0 +1,127 @@
+//! Module containing [`RegistryServer`] to run the registry HTTP server.
+
+use std::sync::Arc;
+
+use axum::{body::Body, extract::Path, http::Response, routing, Extension, Router};
+use bitcoinsuite_core::{Hashed, LotusAddress, LotusAddressError, Net, ScriptVariant};
+use bitcoinsuite_error::{ErrorMeta, Result};
+use cashweb_http_utils::protobuf::Protobuf;
+use thiserror::Error;
+
+use crate::{
+    http::error::HttpRegistryError,
+    proto,
+    registry::Registry,
+    store::pubkeyhash::{PkhAlgorithm, PubKeyHash},
+};
+
+/// Provides endpoints to read and write from the Cashweb Registry.
+#[derive(Debug, Clone)]
+pub struct RegistryServer {
+    /// [`Registry`] this server accesses.
+    pub registry: Arc<Registry>,
+    /// Whether server is running on a mainnet or regtest network.
+    pub net: Net,
+}
+
+/// Errors indicating invalid requests being sent to the Registry endpoint.
+#[derive(Debug, Error, ErrorMeta)]
+pub enum RegistryServerError {
+    /// Provided string doesn't name a known [`PkhAlgorithm`].
+    #[invalid_client_input()]
+    #[error("Invalid public key hash algorithm {0:?}, expected \"p2pkh\"")]
+    InvalidPkhAlgorithm(String),
+
+    /// Invalid lotus address in request.
+    #[invalid_user_input()]
+    #[error("Invalid lotus address: {0}")]
+    InvalidAddress(LotusAddressError),
+
+    /// Invalid lotus address in request.
+    #[invalid_user_input()]
+    #[error("Invalid address net, expected {expected:?} but got {actual:?}")]
+    InvalidAddressNet {
+        /// Net expected by the server.
+        expected: Net,
+        /// Net encoded in the address.
+        actual: Net,
+    },
+
+    /// Invalid lotus address in request.
+    #[invalid_client_input()]
+    #[error("Unsupported address script variant: {0:?}")]
+    UnsupportedScriptVariant(ScriptVariant),
+
+    /// Address metadata not found in registry.
+    #[not_found()]
+    #[error("Not found: No address metadata for {0} in registry")]
+    AddressMetadataNotFound(LotusAddress),
+}
+
+use self::RegistryServerError::*;
+
+impl RegistryServer {
+    /// Turn this registry server into a [`Router`].
+    pub fn into_router(self) -> Router {
+        Router::new()
+            .route(
+                "/metadata/:addr",
+                routing::put(handle_put_registry)
+                    .get(handle_get_registry)
+                    .options(handle_post_options),
+            )
+            .layer(Extension(self))
+    }
+
+    fn parse_address(&self, address: &LotusAddress) -> Result<PubKeyHash> {
+        if address.net() != self.net {
+            return Err(InvalidAddressNet {
+                expected: self.net,
+                actual: address.net(),
+            }
+            .into());
+        }
+        match address.script().parse_variant() {
+            ScriptVariant::P2PKH(hash) => {
+                PubKeyHash::new(PkhAlgorithm::Sha256Ripemd160, hash.as_slice().into())
+            }
+            variant => Err(UnsupportedScriptVariant(variant).into()),
+        }
+    }
+}
+
+async fn handle_post_options() -> Result<Response<Body>, HttpRegistryError> {
+    Response::builder()
+        .header("Allow", "OPTIONS, HEAD, POST, PUT, GET")
+        .body(axum::body::Body::empty())
+        .map_err(|err| HttpRegistryError(err.into()))
+}
+
+async fn handle_put_registry(
+    Path(address): Path<String>,
+    Protobuf(signed_metadata): Protobuf<cashweb_payload::proto::SignedPayload>,
+    Extension(server): Extension<RegistryServer>,
+) -> Result<Protobuf<proto::PutAddressMetadataResponse>, HttpRegistryError> {
+    let address = address.parse::<LotusAddress>().map_err(InvalidAddress)?;
+    let pkh = server.parse_address(&address)?;
+    let txids = server.registry.put_metadata(&pkh, signed_metadata).await?;
+    Ok(Protobuf(proto::PutAddressMetadataResponse {
+        txid: txids
+            .into_iter()
+            .map(|txid| txid.as_slice().to_vec())
+            .collect(),
+    }))
+}
+
+async fn handle_get_registry(
+    Path(address): Path<String>,
+    Extension(server): Extension<RegistryServer>,
+) -> Result<Protobuf<cashweb_payload::proto::SignedPayload>, HttpRegistryError> {
+    let address = address.parse::<LotusAddress>().map_err(InvalidAddress)?;
+    let pkh = server.parse_address(&address)?;
+    let signed_payload = server
+        .registry
+        .get_metadata(&pkh)?
+        .ok_or(AddressMetadataNotFound(address))?;
+    Ok(Protobuf(signed_payload.to_proto()))
+}

--- a/cashweb-registry/src/lib.rs
+++ b/cashweb-registry/src/lib.rs
@@ -8,6 +8,7 @@
 //! `cashweb-registry` is a library for the Registry part of a CashWeb server.
 //! It allows storing and retrieving metadata by addresses (scripts).
 
+pub mod http;
 pub mod registry;
 pub mod store;
 

--- a/cashweb-registry/tests/test_http_endpoint.rs
+++ b/cashweb-registry/tests/test_http_endpoint.rs
@@ -1,0 +1,277 @@
+use std::{net::SocketAddr, sync::Arc, time::Duration};
+
+use bitcoinsuite_bitcoind::instance::{BitcoindChain, BitcoindConf, BitcoindInstance};
+use bitcoinsuite_core::{
+    ecc::Ecc, lotus_txid, BitcoinCode, Hashed, LotusAddress, Net, Network, P2PKHSignatory, Script,
+    SequenceNo, Sha256, ShaRmd160, SigHashType, SignData, SignField, TxBuilder, TxBuilderInput,
+    TxBuilderOutput, TxInput, TxOutput,
+};
+use bitcoinsuite_ecc_secp256k1::EccSecp256k1;
+use bitcoinsuite_error::Result;
+use bitcoinsuite_test_utils::{bin_folder, is_free_tcp, pick_ports};
+use bitcoinsuite_test_utils_blockchain::setup_bitcoind_coins;
+use cashweb_http_utils::protobuf::CONTENT_TYPE_PROTOBUF;
+use cashweb_payload::{payload::SignatureScheme, verify::build_commitment_script};
+use cashweb_registry::{http::server::RegistryServer, proto, registry::Registry, store::db::Db};
+use pretty_assertions::assert_eq;
+use prost::Message;
+use reqwest::{header::CONTENT_TYPE, StatusCode};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_registry_http() -> Result<()> {
+    let _ = bitcoinsuite_error::install();
+    let tempdir = tempdir::TempDir::new("cashweb-registry--registry")?;
+    let db = Db::open(tempdir.path().join("db.rocksdb"))?;
+
+    let conf = BitcoindConf::from_chain_regtest(bin_folder(), BitcoindChain::XPI, vec![])?;
+    let mut instance = BitcoindInstance::setup(conf)?;
+    instance.wait_for_ready()?;
+    let bitcoind = instance.rpc_client().clone();
+
+    let ecc = EccSecp256k1::default();
+    let server = RegistryServer {
+        registry: Arc::new(Registry::new(db, bitcoind)),
+        net: Net::Regtest,
+    };
+
+    let router = server.into_router();
+
+    let port = pick_ports(1)?[0];
+    let socket_addr = format!("127.0.0.1:{}", port).parse::<SocketAddr>()?;
+    let url = format!("http://{}", socket_addr);
+
+    tokio::spawn(axum::Server::bind(&socket_addr).serve(router.into_make_service()));
+
+    let mut attempt = 0;
+    while is_free_tcp(port) {
+        attempt += 1;
+        if attempt > 100 {
+            panic!("Failed to start server");
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    let client = reqwest::Client::new();
+
+    let seckey = ecc.seckey_from_array([5; 32])?;
+    let pubkey = ecc.derive_pubkey(&seckey);
+    let pkh = ShaRmd160::digest(pubkey.array().into());
+    let address = LotusAddress::new("lotus", Net::Regtest, Script::p2pkh(&pkh));
+
+    let mut utxos = setup_bitcoind_coins(
+        instance.cli(),
+        Network::XPI,
+        3,
+        address.as_str(),
+        &address.script().hex(),
+    )?;
+
+    // Invalid address
+    let response = client.get(format!("{}/metadata/A", url)).send().await?;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    check_proto_error(
+        response,
+        "invalid-address",
+        "Invalid lotus address: Missing prefix",
+        true,
+    )
+    .await?;
+
+    // Expected regtest, got mainnet address
+    let response = client
+        .get(format!(
+            "{}/metadata/lotus_16PSJNf1EDEfGvaYzaXJCJZrXH4pgiTo7kyW61iGi",
+            url
+        ))
+        .send()
+        .await?;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    check_proto_error(
+        response,
+        "invalid-address-net",
+        "Invalid address net, expected Regtest but got Mainnet",
+        true,
+    )
+    .await?;
+
+    // Expected P2PKH, got P2SH
+    let response = client
+        .get(format!(
+            "{}/metadata/lotusR1PrQReKdmXH6hyCk4NFR398HeWxvJWW4Hie3rA",
+            url
+        ))
+        .send()
+        .await?;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    check_proto_error(
+        response,
+        "unsupported-script-variant",
+        "Unsupported address script variant: P2SH(ShaRmd160(6a669cafca7fa9ab24ce712f10c968f6eb170626))",
+        false,
+    ).await?;
+
+    // Metadata not found for that address (yet)
+    let response = client
+        .get(format!("{}/metadata/{}", url, address))
+        .send()
+        .await?;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    check_proto_error(
+        response,
+        "address-metadata-not-found",
+        "Not found: No address metadata for lotusR16PSJMw2kpXdpk9Kn7qX6cYA7MbLg23bfTtXL7zeQ in registry",
+        true,
+    ).await?;
+
+    // Build valid request
+    let address_metadata = proto::AddressMetadata {
+        timestamp: 1234,
+        ttl: 10,
+        entries: vec![],
+    };
+    let payload_hash = Sha256::digest(address_metadata.encode_to_vec().into());
+
+    let (outpoint, value) = utxos.pop().unwrap();
+    let burn_amount = 10_000;
+    let tx_builder = TxBuilder {
+        version: 1,
+        inputs: vec![TxBuilderInput::new(
+            TxInput {
+                prev_out: outpoint,
+                script: Script::default(),
+                sequence: SequenceNo::finalized(),
+                sign_data: Some(SignData::new(vec![
+                    SignField::OutputScript(address.script().clone()),
+                    SignField::Value(value),
+                ])),
+            },
+            Box::new(P2PKHSignatory {
+                seckey: seckey.clone(),
+                pubkey,
+                sig_hash_type: SigHashType::ALL_BIP143,
+            }),
+        )],
+        outputs: vec![
+            TxBuilderOutput::Leftover(address.script().clone()),
+            TxBuilderOutput::Fixed(TxOutput {
+                value: burn_amount,
+                script: build_commitment_script(pubkey.array(), &payload_hash),
+            }),
+        ],
+        lock_time: 0,
+    };
+    let tx = tx_builder.sign(&ecc, 1000, 546)?;
+    let mut signed_metadata = cashweb_payload::proto::SignedPayload {
+        pubkey: pubkey.array().to_vec(),
+        sig: vec![], // invalid sig
+        sig_scheme: SignatureScheme::Ecdsa.into(),
+        payload: address_metadata.encode_to_vec(),
+        payload_hash: vec![],
+        burn_amount: 0,
+        burn_txs: vec![cashweb_payload::proto::BurnTx {
+            tx: tx.ser().to_vec(),
+            burn_idx: 1,
+        }],
+    };
+
+    // Missing Content-Type (should be application/x-protobuf).
+    let response = client
+        .put(format!("{}/metadata/{}", url, address))
+        .body(signed_metadata.encode_to_vec())
+        .send()
+        .await?;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    check_proto_error(
+        response,
+        "no-content-type-set",
+        "No Content-Type set",
+        false,
+    )
+    .await?;
+
+    // Invalid ECDSA signature: sig is empty
+    let response = client
+        .put(format!("{}/metadata/{}", url, address))
+        .body(signed_metadata.encode_to_vec())
+        .header(CONTENT_TYPE, CONTENT_TYPE_PROTOBUF)
+        .send()
+        .await?;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    check_proto_error(
+        response,
+        "invalid-ecdsa-signature",
+        "Invalid payload ECDSA signature: Invalid signature format",
+        false,
+    )
+    .await?;
+
+    // Add valid response
+    signed_metadata.sig = ecc
+        .sign(&seckey, payload_hash.byte_array().clone())
+        .to_vec();
+
+    // Now request succeeds
+    let response = client
+        .put(format!("{}/metadata/{}", url, address))
+        .body(signed_metadata.encode_to_vec())
+        .header(CONTENT_TYPE, CONTENT_TYPE_PROTOBUF)
+        .send()
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    let mut body = response.bytes().await?;
+    let broadcast_response = proto::PutAddressMetadataResponse::decode(&mut body)?;
+    assert_eq!(
+        broadcast_response,
+        proto::PutAddressMetadataResponse {
+            txid: vec![lotus_txid(&tx).as_slice().to_vec()],
+        },
+    );
+
+    // Query metadata
+    let response = client
+        .get(format!("{}/metadata/{}", url, address))
+        .send()
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    let mut body = response.bytes().await?;
+    let signed_payload = cashweb_payload::proto::SignedPayload::decode(&mut body)?;
+    signed_metadata.burn_amount = burn_amount;
+    signed_metadata.payload_hash = payload_hash.as_slice().to_vec();
+    assert_eq!(signed_payload, signed_metadata,);
+
+    // PUT again fails (for now)
+    let response = client
+        .put(format!("{}/metadata/{}", url, address))
+        .body(signed_metadata.encode_to_vec())
+        .header(CONTENT_TYPE, CONTENT_TYPE_PROTOBUF)
+        .send()
+        .await?;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    check_proto_error(
+        response,
+        "bitcoind-rejected-tx",
+        "Bitcoind rejected tx: txn-already-in-mempool",
+        true,
+    )
+    .await?;
+
+    Ok(())
+}
+
+async fn check_proto_error(
+    response: reqwest::Response,
+    error_code: &str,
+    msg: &str,
+    is_user_error: bool,
+) -> Result<()> {
+    assert_eq!(response.headers()[CONTENT_TYPE], CONTENT_TYPE_PROTOBUF);
+    let mut body = response.bytes().await?;
+    let actual_error = cashweb_http_utils::proto::Error::decode(&mut body)?;
+    let expected_error = cashweb_http_utils::proto::Error {
+        error_code: error_code.to_string(),
+        msg: msg.to_string(),
+        is_user_error,
+    };
+    assert_eq!(actual_error, expected_error);
+    Ok(())
+}


### PR DESCRIPTION
Adds `/metadata/:address` endpoint for submitting and querying address metadata.