### PR TITLE
Allow already (partially) known SignedPayloads

### DIFF
--- a/cashweb-registry/src/http/server.rs
+++ b/cashweb-registry/src/http/server.rs
@@ -104,9 +104,10 @@ async fn handle_put_registry(
 ) -> Result<Protobuf<proto::PutAddressMetadataResponse>, HttpRegistryError> {
     let address = address.parse::<LotusAddress>().map_err(InvalidAddress)?;
     let pkh = server.parse_address(&address)?;
-    let txids = server.registry.put_metadata(&pkh, signed_metadata).await?;
+    let result = server.registry.put_metadata(&pkh, signed_metadata).await?;
     Ok(Protobuf(proto::PutAddressMetadataResponse {
-        txid: txids
+        txid: result
+            .txids
             .into_iter()
             .map(|txid| txid.as_slice().to_vec())
             .collect(),

--- a/cashweb-registry/src/registry.rs
+++ b/cashweb-registry/src/registry.rs
@@ -1,10 +1,10 @@
 //! Module containing [`Registry`].
 
-use bitcoinsuite_bitcoind::rpc_client::BitcoindRpcClient;
-use bitcoinsuite_core::{Hashed, Sha256d};
+use bitcoinsuite_bitcoind::{rpc_client::BitcoindRpcClient, BitcoindError};
+use bitcoinsuite_core::{lotus_txid, Hashed, Sha256d};
 use bitcoinsuite_ecc_secp256k1::EccSecp256k1;
 use bitcoinsuite_error::{ErrorMeta, Result, WrapErr};
-use cashweb_payload::payload::SignedPayload;
+use cashweb_payload::payload::{BurnTx, SignedPayload};
 use thiserror::Error;
 
 use crate::{
@@ -24,6 +24,37 @@ pub struct Registry {
     bitcoind: BitcoindRpcClient,
 }
 
+/// Result of putting metadata into the registry.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PutMetadataResult {
+    /// Transaction IDs of the burn txs for this payload.
+    pub txids: Vec<Sha256d>,
+    /// Which action happened with the blockchain.
+    pub blockchain_action: PutMetadataBlockchainAction,
+}
+
+/// Which action happened with the blockchain when putting address metadata.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum PutMetadataBlockchainAction {
+    /// Signed payload hash was already the current one in the database.
+    /// Burn transactions were not validated.
+    AlreadyKnowPayloadHash,
+    /// Signed payload new, but txs already seen on the blockchain.
+    /// Tx broadcast is skipped, but malleation is checked.
+    AlreadyKnowTx,
+    /// Txs not seen on the network yet, but between testmempoolaccept and sendrawtransaction,
+    /// a block was found, which would make sendrawtransaction fail.
+    BroadcastRaceCondition,
+    /// Txs not seen on the network yet, and we were able to broadcast them successfully.
+    Broadcast,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum BurnTxValidation {
+    Known,
+    NotYetBroadcast,
+}
+
 /// Errors indicating some registry error.
 #[derive(Debug, Error, ErrorMeta, PartialEq)]
 pub enum RegistryError {
@@ -40,10 +71,31 @@ pub enum RegistryError {
         actual: PubKeyHash,
     },
 
+    /// Timestamps in the address payload must increase monotonically.
+    /// Otherwise, attackers could re-submit old SignedPayloads and make them go back in time.
+    #[invalid_user_input()]
+    #[error("Payload timestamp is not monotonically increasing: {previous} >= {next}")]
+    TimestampNotMonotonicallyIncreasing {
+        /// Current payload timestamp as recorded in the database.
+        previous: i64,
+        /// Timestamp of the new payload.
+        next: i64,
+    },
+
     /// Bitcoind rejected the provided burn tx.
     #[invalid_user_input()]
     #[error("Bitcoind rejected tx: {0}")]
     BitcoindRejectedTx(String),
+
+    /// Tx malleated.
+    #[invalid_user_input()]
+    #[error("Malleated tx, expected {expected}, but got {actual}")]
+    TxMalleated {
+        /// Tx hex as seen by this registry
+        expected: String,
+        /// Malleated tx hex with different input signatures.
+        actual: String,
+    },
 
     /// Database contains an invalid protobuf MetadataEntry.
     #[critical()]
@@ -77,16 +129,14 @@ impl Registry {
             SignedPayload::from_proto(signed_payload).wrap_err(InvalidSignedPayloadInDb)?;
         Ok(Some(signed_payload))
     }
-}
 
-impl Registry {
     /// Fully verify and write a [`cashweb_payload::proto::SignedPayload`](SignedPayload) into the
     /// database.
     pub async fn put_metadata(
         &self,
         pkh: &PubKeyHash,
         signed_metadata: cashweb_payload::proto::SignedPayload,
-    ) -> Result<Vec<Sha256d>> {
+    ) -> Result<PutMetadataResult> {
         // Decode SignedPayload
         let signed_metadata = SignedPayload::<proto::AddressMetadata>::from_proto(signed_metadata)?;
 
@@ -103,35 +153,124 @@ impl Registry {
         // Verify burn amount and signatures check out
         signed_metadata.verify(&self.ecc)?;
 
-        // Verify txs are valid on the network
-        for burn_tx in signed_metadata.txs() {
-            if let Err(msg) = self
-                .bitcoind
-                .test_mempool_accept(burn_tx.tx().raw())
-                .await?
-            {
-                return Err(RegistryError::BitcoindRejectedTx(msg).into());
+        if let Some(existing_metadata) = self.get_metadata(pkh)? {
+            // If existing payload hash is the same as the new payload hash,
+            // we don't need to verify anything.
+            if signed_metadata.payload_hash() == existing_metadata.payload_hash() {
+                return Ok(PutMetadataResult {
+                    txids: signed_metadata
+                        .txs()
+                        .iter()
+                        .map(|tx| lotus_txid(tx.tx().unhashed_tx()))
+                        .collect(),
+                    blockchain_action: PutMetadataBlockchainAction::AlreadyKnowPayloadHash,
+                });
             }
+            // Timestamp needs to be ascending.
+            if existing_metadata.payload().timestamp >= signed_metadata.payload().timestamp {
+                return Err(TimestampNotMonotonicallyIncreasing {
+                    previous: existing_metadata.payload().timestamp,
+                    next: signed_metadata.payload().timestamp,
+                }
+                .into());
+            }
+        }
+
+        // Verify txs are valid on the network
+        let mut validations = Vec::with_capacity(signed_metadata.txs().len());
+        for burn_tx in signed_metadata.txs() {
+            validations.push(self.validate_burn_tx(burn_tx).await?);
         }
 
         // Broadcast txs onto the network
         let mut txids = Vec::with_capacity(signed_metadata.txs().len());
-        for burn_tx in signed_metadata.txs() {
-            let txid_hex = self
+        let mut blockchain_action = PutMetadataBlockchainAction::Broadcast;
+        for (burn_tx, validation) in signed_metadata.txs().iter().zip(validations) {
+            if validation == BurnTxValidation::Known {
+                txids.push(lotus_txid(burn_tx.tx().unhashed_tx()));
+                if blockchain_action == PutMetadataBlockchainAction::Broadcast {
+                    blockchain_action = PutMetadataBlockchainAction::AlreadyKnowTx;
+                }
+                continue;
+            }
+            let broadcast_result = self
                 .bitcoind
                 .cmd_text("sendrawtransaction", &[burn_tx.tx().raw().hex().into()])
-                .await?;
-            txids.push(Sha256d::from_hex_be(&txid_hex)?);
+                .await;
+            match broadcast_result {
+                Ok(txid_hex) => {
+                    txids.push(Sha256d::from_hex_be(&txid_hex)?);
+                }
+                Err(err) => {
+                    // sendrawtransaction failed as there was a block found since the
+                    // testmempoolaccept. We handle this gracefully.
+                    let err = err.downcast::<BitcoindError>()?;
+                    match err {
+                        BitcoindError::JsonRpcCode { code: -27, .. } => {
+                            txids.push(lotus_txid(burn_tx.tx().unhashed_tx()));
+                            blockchain_action = PutMetadataBlockchainAction::BroadcastRaceCondition;
+                        }
+                        err => return Err(err.into()),
+                    }
+                }
+            }
         }
 
         // Write new metadata into the database
         self.db.metadata().put(pkh, &signed_metadata.to_proto())?;
-        Ok(txids)
+        Ok(PutMetadataResult {
+            txids,
+            blockchain_action,
+        })
+    }
+
+    async fn validate_burn_tx(&self, burn_tx: &BurnTx) -> Result<BurnTxValidation> {
+        let txid = lotus_txid(burn_tx.tx().unhashed_tx());
+        match self
+            .bitcoind
+            .cmd_text("getrawtransaction", &[txid.to_string().into()])
+            .await
+        {
+            // Found txid
+            Ok(tx_hex) => {
+                let tx_raw = hex::decode(&tx_hex)?;
+                if tx_raw != burn_tx.tx().raw().as_ref() {
+                    return Err(TxMalleated {
+                        expected: tx_hex,
+                        actual: burn_tx.tx().raw().hex(),
+                    }
+                    .into());
+                }
+                Ok(BurnTxValidation::Known)
+            }
+            // Txid not found
+            Err(err) => {
+                let err = err.downcast::<BitcoindError>()?;
+                match err {
+                    BitcoindError::JsonRpcCode { code: -5, message }
+                        if message.starts_with("No such mempool or blockchain transaction.") =>
+                    {
+                        // Test tx mempool acceptance
+                        if let Err(msg) = self
+                            .bitcoind
+                            .test_mempool_accept(burn_tx.tx().raw())
+                            .await?
+                        {
+                            return Err(RegistryError::BitcoindRejectedTx(msg).into());
+                        }
+                        Ok(BurnTxValidation::NotYetBroadcast)
+                    }
+                    err => Err(err.into()),
+                }
+            }
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::ffi::OsString;
+
     use bitcoinsuite_bitcoind::instance::{BitcoindChain, BitcoindConf, BitcoindInstance};
     use bitcoinsuite_core::{
         ecc::{Ecc, VerifySignatureError},
@@ -152,7 +291,7 @@ mod tests {
 
     use crate::{
         proto,
-        registry::{Registry, RegistryError},
+        registry::{PutMetadataBlockchainAction, PutMetadataResult, Registry, RegistryError},
         store::{
             db::Db,
             pubkeyhash::{PkhAlgorithm, PubKeyHash},
@@ -165,7 +304,11 @@ mod tests {
         let tempdir = tempdir::TempDir::new("cashweb-registry--registry")?;
         let db = Db::open(tempdir.path().join("db.rocksdb"))?;
 
-        let conf = BitcoindConf::from_chain_regtest(bin_folder(), BitcoindChain::XPI, vec![])?;
+        let conf = BitcoindConf::from_chain_regtest(
+            bin_folder(),
+            BitcoindChain::XPI,
+            vec![OsString::from("-txindex")],
+        )?;
         let mut instance = BitcoindInstance::setup(conf)?;
         instance.wait_for_ready()?;
         let bitcoind = instance.rpc_client();
@@ -188,7 +331,7 @@ mod tests {
         let mut utxos = setup_bitcoind_coins(
             instance.cli(),
             Network::XPI,
-            3,
+            100,
             address.as_str(),
             &address.to_script().hex(),
         )?;
@@ -306,8 +449,14 @@ mod tests {
         signed_metadata.burn_amount = burn_amount;
 
         // Now, putting the metadata succeeds
-        let txids = registry.put_metadata(&pkh, signed_metadata.clone()).await?;
-        assert_eq!(txids, vec![lotus_txid(&tx)]);
+        let result = registry.put_metadata(&pkh, signed_metadata.clone()).await?;
+        assert_eq!(
+            result,
+            PutMetadataResult {
+                txids: vec![lotus_txid(&tx)],
+                blockchain_action: PutMetadataBlockchainAction::Broadcast,
+            }
+        );
 
         let signed_payload = registry.get_metadata(&pkh)?;
         assert_eq!(
@@ -315,64 +464,214 @@ mod tests {
             Some(SignedPayload::from_proto(signed_metadata.clone())?),
         );
 
-        // Override address metadata with new SignedPayload
-        let mut address_metadata = address_metadata.clone();
-        let mut signed_metadata2 = signed_metadata.clone();
-        address_metadata.timestamp = 5555;
-
-        signed_metadata2.payload = address_metadata.encode_to_vec();
-        let payload_hash = Sha256::digest(signed_metadata2.payload.clone().into());
-        signed_metadata2.payload_hash = payload_hash.as_slice().to_vec();
-        signed_metadata2.sig = registry
-            .ecc
-            .sign(&seckey, payload_hash.byte_array().clone())
-            .to_vec();
-
-        let (outpoint, value) = utxos.pop().unwrap();
-        let burn_amount = value - 11_000;
-        let tx_builder = TxBuilder {
-            version: 1,
-            inputs: vec![TxBuilderInput::new(
-                TxInput {
-                    prev_out: outpoint,
-                    script: Script::default(),
-                    sequence: SequenceNo::finalized(),
-                    sign_data: Some(SignData::new(vec![
-                        SignField::OutputScript(address.to_script()),
-                        SignField::Value(value),
-                    ])),
-                },
-                Box::new(P2PKHSignatory {
-                    seckey,
-                    pubkey,
-                    sig_hash_type: SigHashType::ALL_BIP143,
-                }),
-            )],
-            outputs: vec![
-                TxBuilderOutput::Leftover(address.to_script()),
-                TxBuilderOutput::Fixed(TxOutput {
-                    value: burn_amount,
-                    script: build_commitment_script(pubkey.array(), &payload_hash),
-                }),
-            ],
-            lock_time: 0,
-        };
-        signed_metadata2.burn_amount = burn_amount;
-        let tx2 = tx_builder.sign(&registry.ecc, 1000, 546)?;
-        signed_metadata2.burn_txs[0].tx = tx2.ser().to_vec();
-        signed_metadata2.burn_txs[0].burn_idx = 1;
-
-        let txids = registry
-            .put_metadata(&pkh, signed_metadata2.clone())
-            .await?;
-        assert_eq!(txids, vec![lotus_txid(&tx2)]);
-
-        let signed_payload2 = registry.get_metadata(&pkh)?;
-        assert_ne!(signed_payload2, signed_payload);
+        // Putting the exact same metadata again works, the node already knows the payload hash.
+        let result = registry.put_metadata(&pkh, signed_metadata.clone()).await?;
         assert_eq!(
-            signed_payload2,
-            Some(SignedPayload::from_proto(signed_metadata2)?)
+            result,
+            PutMetadataResult {
+                txids: vec![lotus_txid(&tx)],
+                blockchain_action: PutMetadataBlockchainAction::AlreadyKnowPayloadHash,
+            }
         );
+
+        // Override address metadata with new SignedPayload
+        let mut build_signed_metadata = |address_metadata: proto::AddressMetadata| -> Result<_> {
+            let mut signed_metadata = signed_metadata.clone();
+
+            signed_metadata.payload = address_metadata.encode_to_vec();
+            let payload_hash = Sha256::digest(signed_metadata.payload.clone().into());
+            signed_metadata.payload_hash = payload_hash.as_slice().to_vec();
+            signed_metadata.sig = registry
+                .ecc
+                .sign(&seckey, payload_hash.byte_array().clone())
+                .to_vec();
+
+            let (outpoint, value) = utxos.pop().unwrap();
+            let burn_amount = 10_000;
+            let tx_builder = TxBuilder {
+                version: 1,
+                inputs: vec![TxBuilderInput::new(
+                    TxInput {
+                        prev_out: outpoint,
+                        script: Script::default(),
+                        sequence: SequenceNo::finalized(),
+                        sign_data: Some(SignData::new(vec![
+                            SignField::OutputScript(address.to_script()),
+                            SignField::Value(value),
+                        ])),
+                    },
+                    Box::new(P2PKHSignatory {
+                        seckey: seckey.clone(),
+                        pubkey,
+                        sig_hash_type: SigHashType::ALL_BIP143,
+                    }),
+                )],
+                outputs: vec![
+                    TxBuilderOutput::Leftover(address.to_script()),
+                    TxBuilderOutput::Fixed(TxOutput {
+                        value: burn_amount,
+                        script: build_commitment_script(pubkey.array(), &payload_hash),
+                    }),
+                ],
+                lock_time: 0,
+            };
+            signed_metadata.burn_amount = burn_amount;
+            let tx = tx_builder.sign(&registry.ecc, 1000, 546)?;
+            signed_metadata.burn_txs[0].tx = tx.ser().to_vec();
+            signed_metadata.burn_txs[0].burn_idx = 1;
+            Ok((signed_metadata, tx))
+        };
+
+        let (signed_metadata, _) = build_signed_metadata(proto::AddressMetadata {
+            timestamp: 1234,
+            ttl: 10,
+            entries: vec![proto::AddressEntry {
+                kind: "test".to_string(),
+                headers: [].into(),
+                body: vec![],
+            }],
+        })?;
+        let err = registry
+            .put_metadata(&pkh, signed_metadata)
+            .await
+            .unwrap_err()
+            .downcast::<RegistryError>()?;
+        assert_eq!(
+            err,
+            RegistryError::TimestampNotMonotonicallyIncreasing {
+                previous: 1234,
+                next: 1234,
+            },
+        );
+
+        // With more recent timestamp, it succeeds.
+        let (signed_metadata, tx) = build_signed_metadata(proto::AddressMetadata {
+            timestamp: 1235,
+            ttl: 10,
+            entries: vec![],
+        })?;
+        let result = registry.put_metadata(&pkh, signed_metadata.clone()).await?;
+        assert_eq!(
+            result,
+            PutMetadataResult {
+                txids: vec![lotus_txid(&tx)],
+                blockchain_action: PutMetadataBlockchainAction::Broadcast,
+            }
+        );
+
+        assert_eq!(
+            registry.get_metadata(&pkh)?,
+            Some(SignedPayload::from_proto(signed_metadata)?)
+        );
+
+        let (signed_metadata, tx) = build_signed_metadata(proto::AddressMetadata {
+            timestamp: 1236,
+            ttl: 10,
+            entries: vec![],
+        })?;
+        // pre-broadcast tx works
+        bitcoind
+            .cmd_text("sendrawtransaction", &[tx.ser().hex().into()])
+            .await?;
+        // Mine block: This would make another "sendrawtransaction" of `tx` fail.
+        bitcoind
+            .cmd_text("generatetoaddress", &[1i32.into(), address.as_str().into()])
+            .await?;
+        let result = registry.put_metadata(&pkh, signed_metadata.clone()).await?;
+        assert_eq!(
+            result,
+            PutMetadataResult {
+                txids: vec![lotus_txid(&tx)],
+                blockchain_action: PutMetadataBlockchainAction::AlreadyKnowTx,
+            }
+        );
+
+        assert_eq!(
+            registry.get_metadata(&pkh)?,
+            Some(SignedPayload::from_proto(signed_metadata.clone())?),
+        );
+
+        // Malleate tx, will result in a different txid, but same raw tx hex
+        let (mut signed_metadata, tx) = build_signed_metadata(proto::AddressMetadata {
+            timestamp: 1237,
+            ttl: 10,
+            entries: vec![],
+        })?;
+        bitcoind
+            .cmd_text("sendrawtransaction", &[tx.ser().hex().into()])
+            .await?;
+        let old_tx = tx.clone();
+        let mut tx_builder = TxBuilder::from_tx(tx);
+        *tx_builder.inputs[0].signatory_mut() = Some(Box::new(P2PKHSignatory {
+            seckey: seckey.clone(),
+            pubkey,
+            sig_hash_type: SigHashType::ALL_BIP143,
+        }));
+        let tx = tx_builder.sign(&registry.ecc, 1000, 546)?;
+        assert_ne!(old_tx, tx);
+        signed_metadata.burn_txs[0].tx = tx.ser().to_vec();
+        let err = registry
+            .put_metadata(&pkh, signed_metadata)
+            .await
+            .unwrap_err()
+            .downcast::<RegistryError>()?;
+        assert_eq!(
+            err,
+            RegistryError::TxMalleated {
+                expected: old_tx.ser().hex(),
+                actual: tx.ser().hex(),
+            },
+        );
+
+        // this test is incredibly flaky, only meant to be run to verify race condition handling
+        if false {
+            let mut found_any_race_condition = false;
+            for i in 3..95 {
+                let (signed_metadata, tx) = build_signed_metadata(proto::AddressMetadata {
+                    timestamp: 1234 + i,
+                    ttl: 10,
+                    entries: vec![],
+                })?;
+                println!("**** i = {}", i);
+                // pre-broadcast tx works
+                // Race condition:
+                // Mine block: This would make another "sendrawtransaction" of `tx` fail.
+                let handle = tokio::spawn({
+                    let address = address.clone();
+                    let bitcoind = bitcoind.clone();
+                    let tx = tx.clone();
+                    async move {
+                        tokio::time::sleep(std::time::Duration::from_micros(3 + (i * 3) as u64))
+                            .await;
+                        bitcoind
+                            .cmd_text("sendrawtransaction", &[tx.ser().hex().into()])
+                            .await
+                            .unwrap();
+                        bitcoind
+                            .cmd_text("generatetoaddress", &[1i32.into(), address.as_str().into()])
+                            .await
+                            .unwrap();
+                    }
+                });
+                let result = registry.put_metadata(&pkh, signed_metadata.clone()).await;
+                if let Ok(result) = result {
+                    if result.blockchain_action
+                        == PutMetadataBlockchainAction::BroadcastRaceCondition
+                    {
+                        found_any_race_condition = true;
+                        break;
+                    }
+                }
+                handle.await?;
+            }
+
+            assert!(
+                found_any_race_condition,
+                "No block race condition could be simulated",
+            );
+        }
+
+        instance.cleanup()?;
 
         Ok(())
     }


### PR DESCRIPTION
This is important for allowing peering, where peers send SignedPayloads to each other in a peer-to-peer fashion.

- If a node already has an entry for the pkh:
  - and the payload hash is identical, it returns success immediately,
  - otherwise, the timestamp of the address metadata must be ascending.
- If it already knows the burn txs (through testmempoolaccept), it skips broadcasting them
- Otherwise it broadcasts them
- A broadcast can fail if the tx has been mined between testmempoolaccept and sendrawtransaction. This is handled as a success.