### PR TITLE
Refactor: `from_proto` to `parse_proto`

### DIFF
--- a/cashweb-registry/src/http/server.rs
+++ b/cashweb-registry/src/http/server.rs
@@ -62,7 +62,7 @@ async fn handle_put_registry(
     let address = address.parse::<LotusAddress>().map_err(InvalidAddress)?;
     let result = server
         .registry
-        .put_metadata(&address, signed_metadata)
+        .put_metadata(&address, &signed_metadata)
         .await?;
     Ok(Protobuf(proto::PutAddressMetadataResponse {
         txid: result


### PR DESCRIPTION
Previously, `from_proto` would take ownership of the value. In practice, that actually wasn't used though, so the function was changed to take by reference.

Since `from` implies taking ownership, the function was renamed to `parse_proto`.