### PR TITLE
Add `Peers`, relay messages to peers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,6 +421,7 @@ dependencies = [
  "bloom",
  "cashweb-http-utils",
  "cashweb-payload",
+ "futures",
  "hex",
  "json",
  "pretty_assertions",

--- a/cashweb-registry/Cargo.toml
+++ b/cashweb-registry/Cargo.toml
@@ -8,6 +8,7 @@ bitcoinsuite-core = { path = "../../bitcoinsuite/bitcoinsuite-core" }
 bitcoinsuite-bitcoind = { path = "../../bitcoinsuite/bitcoinsuite-bitcoind" }
 bitcoinsuite-error = { path = "../../bitcoinsuite/bitcoinsuite-error" }
 bitcoinsuite-ecc-secp256k1 = { path = "../../bitcoinsuite/bitcoinsuite-ecc-secp256k1" }
+bitcoinsuite-test-utils = { path = "../../bitcoinsuite/bitcoinsuite-test-utils" }
 
 cashweb-http-utils = { path = "../cashweb-http-utils" }
 cashweb-payload = { path = "../cashweb-payload" }
@@ -17,6 +18,9 @@ axum = { version = "0.5", features = ["ws"] }
 
 # Bloom filter for an approximate set
 bloom = "0.3"
+
+# Common library for anything futures related
+futures = "0.3"
 
 # Build JSON objects
 json = "0.12"
@@ -48,7 +52,6 @@ prost-build = "0.10"
 
 [dev-dependencies]
 bitcoinsuite-ecc-secp256k1 = { path = "../../bitcoinsuite/bitcoinsuite-ecc-secp256k1" }
-bitcoinsuite-test-utils = { path = "../../bitcoinsuite/bitcoinsuite-test-utils" }
 bitcoinsuite-test-utils-blockchain = { path = "../../bitcoinsuite/bitcoinsuite-test-utils-blockchain" }
 
 # assert_eq! and assert_ne! with colored diffs

--- a/cashweb-registry/src/http/error.rs
+++ b/cashweb-registry/src/http/error.rs
@@ -6,7 +6,8 @@ use bitcoinsuite_error::{report_to_details, ErrorMeta, Report};
 use cashweb_http_utils::error::details_to_status_proto;
 
 use crate::{
-    http::server::RegistryServerError, registry::RegistryError, store::pubkeyhash::PkhError,
+    http::server::RegistryServerError, p2p::relay_info::RelayInfoError, registry::RegistryError,
+    store::pubkeyhash::PkhError,
 };
 
 /// Newtype around [`Report`], implements [`IntoResponse`].
@@ -39,6 +40,8 @@ pub fn report_to_error_meta(report: &Report) -> Option<&dyn ErrorMeta> {
     } else if let Some(err) = report.downcast_ref::<RegistryError>() {
         Some(err)
     } else if let Some(err) = report.downcast_ref::<PkhError>() {
+        Some(err)
+    } else if let Some(err) = report.downcast_ref::<RelayInfoError>() {
         Some(err)
     } else if let Some(err) = cashweb_payload::error::report_to_error_meta(report) {
         Some(err)

--- a/cashweb-registry/src/lib.rs
+++ b/cashweb-registry/src/lib.rs
@@ -12,6 +12,7 @@ pub mod http;
 pub mod p2p;
 pub mod registry;
 pub mod store;
+pub mod test_instance;
 
 pub mod proto {
     //! Protobuf structs for SignedPayload.

--- a/cashweb-registry/src/p2p/mod.rs
+++ b/cashweb-registry/src/p2p/mod.rs
@@ -1,4 +1,5 @@
 //! Modules related to peer-to-peer relaying of messages.
 
 pub mod peer;
+pub mod peers;
 pub mod relay_info;

--- a/cashweb-registry/src/p2p/peers.rs
+++ b/cashweb-registry/src/p2p/peers.rs
@@ -1,0 +1,49 @@
+//! Module containing [`Peers`].
+
+use cashweb_payload::payload::SignedPayload;
+
+use crate::{
+    http::server::PutMetadataRequest,
+    p2p::{peer::Peer, relay_info::RelayInfo},
+    proto,
+};
+
+/// Peers the Cashweb registry is connected to.
+#[derive(Debug)]
+pub struct Peers {
+    client: reqwest::Client,
+    own_origin: String,
+    /// List of [`Peer`] instances connected to the registry server.
+    pub peers: Vec<Peer>,
+}
+
+impl Peers {
+    /// Create [`Peers`] from a fixed list of peers.
+    pub fn new(own_origin: String, peers: Vec<Peer>) -> Self {
+        Peers {
+            client: reqwest::Client::new(),
+            own_origin,
+            peers,
+        }
+    }
+
+    /// Relay the metadata to all the peers.
+    /// It will not forward to peers that (probably) already know the payload.
+    pub async fn relay_metadata(
+        &self,
+        relay_info: &RelayInfo,
+        request: &PutMetadataRequest,
+        signed_metadata: &SignedPayload<proto::AddressMetadata>,
+    ) {
+        futures::future::join_all(self.peers.iter().map(|peer| {
+            peer.relay_to(
+                relay_info,
+                request,
+                signed_metadata,
+                &self.own_origin,
+                &self.client,
+            )
+        }))
+        .await;
+    }
+}

--- a/cashweb-registry/src/test_instance.rs
+++ b/cashweb-registry/src/test_instance.rs
@@ -1,0 +1,85 @@
+//! Module for [`RegistryTestInstance`].
+
+use std::{net::SocketAddr, path::Path, sync::Arc, time::Duration};
+
+use bitcoinsuite_bitcoind::instance::{BitcoindConf, BitcoindInstance};
+use bitcoinsuite_core::Net;
+use bitcoinsuite_error::Result;
+use bitcoinsuite_test_utils::{is_free_tcp, pick_ports};
+
+use crate::{
+    http::server::RegistryServer,
+    p2p::{peer::Peer, peers::Peers},
+    registry::Registry,
+    store::db::Db,
+};
+
+/// A Registry instance connected to a regtest bitcoind instance.
+#[derive(Debug)]
+pub struct RegistryTestInstance {
+    /// Regtest bitcoind instance.
+    pub bitcoind: BitcoindInstance,
+    /// URL of the registry server.
+    pub url: String,
+    /// Port of the registry server.
+    pub port: u16,
+    /// Registry of the server.
+    pub registry: Arc<Registry>,
+    /// Peers of the server.
+    pub peers: Arc<Peers>,
+}
+
+impl RegistryTestInstance {
+    /// Setup a new bitcoind and registry instance on regtest.
+    pub async fn setup(dir: &Path, conf: BitcoindConf, peers: Vec<Peer>) -> Result<Self> {
+        let db = Db::open(dir.join("db.rocksdb"))?;
+
+        let bitcoind = BitcoindInstance::setup(conf)?;
+
+        let port = pick_ports(1)?[0];
+        let socket_addr = format!("127.0.0.1:{}", port).parse::<SocketAddr>()?;
+        let url = format!("http://{}", socket_addr);
+
+        let registry = Arc::new(Registry::new(
+            db,
+            bitcoind.rpc_client().clone(),
+            Net::Regtest,
+        ));
+        let peers = Arc::new(Peers::new(url.clone(), peers));
+        let server = RegistryServer {
+            registry: Arc::clone(&registry),
+            peers: Arc::clone(&peers),
+        };
+
+        let router = server.into_router();
+
+        tokio::spawn(axum::Server::bind(&socket_addr).serve(router.into_make_service()));
+
+        Ok(RegistryTestInstance {
+            bitcoind,
+            url,
+            port,
+            registry,
+            peers,
+        })
+    }
+
+    /// Wait until the bitcoind and registry server are live.
+    pub async fn wait_for_ready(&mut self) -> Result<()> {
+        self.bitcoind.wait_for_ready()?;
+        let mut attempt = 0;
+        while is_free_tcp(self.port) {
+            attempt += 1;
+            if attempt > 100 {
+                panic!("Failed to start server");
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        Ok(())
+    }
+
+    /// Clean up the instance.
+    pub fn cleanup(&self) -> Result<()> {
+        self.bitcoind.cleanup()
+    }
+}

--- a/cashweb-registry/tests/test_p2p.rs
+++ b/cashweb-registry/tests/test_p2p.rs
@@ -1,0 +1,205 @@
+use std::{ffi::OsString, time::Duration};
+
+use bitcoinsuite_bitcoind::instance::{BitcoindChain, BitcoindConf};
+use bitcoinsuite_core::{
+    ecc::Ecc, lotus_txid, BitcoinCode, Hashed, LotusAddress, Net, Network, Script, Sha256,
+    ShaRmd160, TxOutput,
+};
+use bitcoinsuite_ecc_secp256k1::EccSecp256k1;
+use bitcoinsuite_error::Result;
+use bitcoinsuite_test_utils::bin_folder;
+use bitcoinsuite_test_utils_blockchain::{build_tx, setup_bitcoind_coins};
+use cashweb_http_utils::protobuf::CONTENT_TYPE_PROTOBUF;
+use cashweb_payload::{payload::SignatureScheme, verify::build_commitment_script};
+use cashweb_registry::{p2p::peer::Peer, proto, test_instance::RegistryTestInstance};
+use prost::Message;
+use reqwest::{
+    header::{CONTENT_TYPE, ORIGIN},
+    StatusCode,
+};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_p2p() -> Result<()> {
+    let _ = bitcoinsuite_error::install();
+
+    let num_instances = 3;
+    let mut instances = Vec::<RegistryTestInstance>::new();
+    let mut tempdirs = Vec::<tempdir::TempDir>::new();
+
+    // Spin up a few Registry servers.
+    for i in 0..num_instances {
+        let tempdir = tempdir::TempDir::new(&format!("cashweb-registry--registry-{}", i))?;
+
+        let mut additional_args = vec![OsString::from("-txindex")];
+        let mut peers = Vec::new();
+        for instance in &instances {
+            additional_args
+                .push(format!("-addnode=127.0.0.1:{}", instance.bitcoind.p2p_port()).into());
+        }
+        if let Some(instance) = instances.last() {
+            peers.push(Peer::new(instance.url.parse()?));
+        }
+        let conf =
+            BitcoindConf::from_chain_regtest(bin_folder(), BitcoindChain::XPI, additional_args)?;
+
+        let instance = RegistryTestInstance::setup(tempdir.path(), conf, peers).await?;
+        instances.push(instance);
+        tempdirs.push(tempdir);
+    }
+
+    for instance in &mut instances {
+        instance.wait_for_ready().await?;
+    }
+
+    // Generate a few anyone can spend coins
+    let anyone_script = Script::from_slice(&[0x51]);
+    let anyone_address = LotusAddress::new(
+        "lotus",
+        Net::Regtest,
+        Script::p2sh(&ShaRmd160::digest(anyone_script.bytecode().clone())),
+    );
+    let mut utxos = setup_bitcoind_coins(
+        instances[0].bitcoind.cli(),
+        Network::XPI,
+        3,
+        anyone_address.as_str(),
+        &anyone_address.script().hex(),
+    )?;
+    let last_block_hash = instances[0]
+        .bitcoind
+        .cli()
+        .cmd_string("getbestblockhash", &[])?;
+
+    // Wait for all instances to have received the generated coins.
+    let mut attempt = 0;
+    while instances.iter().any(|instance| {
+        instance
+            .bitcoind
+            .cmd_string("getblock", &[&last_block_hash])
+            .is_err()
+    }) {
+        attempt += 1;
+        if attempt > 100 {
+            panic!("Failed to broadcast blocks");
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    // Make new p2pkh address
+    let ecc = EccSecp256k1::default();
+    let seckey = ecc.seckey_from_array([5; 32])?;
+    let pubkey = ecc.derive_pubkey(&seckey);
+    let pkh = ShaRmd160::digest(pubkey.array().into());
+    let address = LotusAddress::new("lotus", Net::Regtest, Script::p2pkh(&pkh));
+
+    // Build valid address metadata
+    let address_metadata = proto::AddressMetadata {
+        timestamp: 1234,
+        ttl: 10,
+        entries: vec![],
+    };
+    let payload_hash = Sha256::digest(address_metadata.encode_to_vec().into());
+
+    // Build burn commitment tx
+    let (outpoint, amount) = utxos.pop().unwrap();
+    let burn_amount = amount - 10_000;
+    let tx = build_tx(
+        outpoint,
+        &anyone_script,
+        vec![TxOutput {
+            value: burn_amount,
+            script: build_commitment_script(pubkey.array(), &payload_hash),
+        }],
+    );
+
+    // Sign address metadata
+    let signed_metadata = cashweb_payload::proto::SignedPayload {
+        pubkey: pubkey.array().to_vec(),
+        sig: ecc
+            .sign(&seckey, payload_hash.byte_array().clone())
+            .to_vec(),
+        sig_scheme: SignatureScheme::Ecdsa.into(),
+        payload: address_metadata.encode_to_vec(),
+        payload_hash: payload_hash.as_slice().to_vec(),
+        burn_amount,
+        burn_txs: vec![cashweb_payload::proto::BurnTx {
+            tx: tx.ser().to_vec(),
+            burn_idx: 0,
+        }],
+    };
+
+    // Send request to last instance
+    let client = reqwest::Client::new();
+    let response = client
+        .put(format!("{}/metadata/{}", instances[2].url, address))
+        .body(signed_metadata.encode_to_vec())
+        .header(CONTENT_TYPE, CONTENT_TYPE_PROTOBUF)
+        .header(ORIGIN, "http://anywhere.com")
+        .send()
+        .await?;
+
+    // Check request accepted
+    assert_eq!(response.status(), StatusCode::OK);
+    let mut body = response.bytes().await?;
+    let broadcast_response = proto::PutAddressMetadataResponse::decode(&mut body)?;
+    assert_eq!(
+        broadcast_response,
+        proto::PutAddressMetadataResponse {
+            txid: vec![lotus_txid(&tx).as_slice().to_vec()],
+        },
+    );
+
+    // Wait for metadata to be relayed to middle instance
+    let mut attempt = 0i32;
+    loop {
+        let state = instances[2].peers.peers[0].state.lock().await;
+        if state.last_status.is_some() {
+            assert_eq!(state.last_status, Some(StatusCode::OK));
+            break;
+        }
+        std::mem::drop(state);
+        attempt += 1;
+        if attempt > 100 {
+            panic!("Failed to broadcast metadata");
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    // Query middle instance about the metadata
+    let response = client
+        .get(format!("{}/metadata/{}", instances[1].url, address))
+        .send()
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    let mut body = response.bytes().await?;
+    let signed_payload = cashweb_payload::proto::SignedPayload::decode(&mut body)?;
+    assert_eq!(signed_payload, signed_metadata);
+
+    // Wait for metadata to be relayed to the first instance
+    let mut attempt = 0i32;
+    loop {
+        let state = instances[1].peers.peers[0].state.lock().await;
+        if state.last_status.is_some() {
+            assert_eq!(state.last_status, Some(StatusCode::OK));
+            break;
+        }
+        std::mem::drop(state);
+        attempt += 1;
+        if attempt > 100 {
+            panic!("Failed to broadcast metadata");
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    // Query first instance
+    let response = client
+        .get(format!("{}/metadata/{}", instances[0].url, address))
+        .send()
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    let mut body = response.bytes().await?;
+    let signed_payload = cashweb_payload::proto::SignedPayload::decode(&mut body)?;
+    assert_eq!(signed_payload, signed_metadata);
+
+    Ok(())
+}


### PR DESCRIPTION
- Add new `Peers` to `RegistryServer`.
- Add `RegistryTestInstance` to setup a new Registry instance easily.
- Relay new metadata using `Peers` after successful PUT.
- Make some fields in `Peer` and `PeerState` public for testing.
- Make `test_http_endpoint.rs` use `RegistryTestInstance`.