### PR TITLE
Add `pkh_by_time` cf, stores pkh ordered by time

### DIFF
--- a/cashweb-registry/src/registry.rs
+++ b/cashweb-registry/src/registry.rs
@@ -3,7 +3,7 @@
 use bitcoinsuite_bitcoind::{rpc_client::BitcoindRpcClient, BitcoindError};
 use bitcoinsuite_core::{lotus_txid, Hashed, LotusAddress, Net, Sha256d};
 use bitcoinsuite_ecc_secp256k1::EccSecp256k1;
-use bitcoinsuite_error::{ErrorMeta, Result, WrapErr};
+use bitcoinsuite_error::{ErrorMeta, Result};
 use cashweb_payload::payload::{BurnTx, SignedPayload};
 use thiserror::Error;
 
@@ -100,11 +100,6 @@ pub enum RegistryError {
         /// Malleated tx hex with different input signatures.
         actual: String,
     },
-
-    /// Database contains an invalid protobuf MetadataEntry.
-    #[critical()]
-    #[error("Inconsistent db: Invalid SignedPayload in DB")]
-    InvalidSignedPayloadInDb,
 }
 
 use self::RegistryError::*;
@@ -138,8 +133,6 @@ impl Registry {
             Some(signed_payload) => signed_payload,
             None => return Ok(None),
         };
-        let signed_payload =
-            SignedPayload::parse_proto(&signed_payload).wrap_err(InvalidSignedPayloadInDb)?;
         Ok(Some(signed_payload))
     }
 
@@ -234,7 +227,7 @@ impl Registry {
         }
 
         // Write new metadata into the database
-        self.db.metadata().put(&pkh, &signed_metadata.to_proto())?;
+        self.db.metadata().put(&pkh, &signed_metadata)?;
         Ok(PutMetadataResult {
             txids,
             blockchain_action,

--- a/cashweb-registry/src/store/db.rs
+++ b/cashweb-registry/src/store/db.rs
@@ -11,6 +11,7 @@ use crate::store::metadata::DbMetadata;
 // We collect the column family constants here so we have a nice overview.
 // This makes it easier to keep cf names consistent and non-conflicting.
 pub(crate) const CF_METADATA: &str = "metadata";
+pub(crate) const CF_PKH_BY_TIME: &str = "pkh_by_time";
 
 pub(crate) type CF = rocksdb::ColumnFamily;
 
@@ -76,6 +77,7 @@ impl Db {
         self.db.get_pinned_cf(cf, key).wrap_err(RocksDb)
     }
 
+    #[cfg(test)]
     pub(crate) fn put(
         &self,
         cf: &CF,
@@ -83,6 +85,15 @@ impl Db {
         value: impl AsRef<[u8]>,
     ) -> Result<()> {
         self.db.put_cf(cf, key, value).wrap_err(RocksDb)
+    }
+
+    pub(crate) fn rocksdb(&self) -> &rocksdb::DB {
+        &self.db
+    }
+
+    pub(crate) fn write_batch(&self, write_batch: rocksdb::WriteBatch) -> Result<()> {
+        self.db.write(write_batch)?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Also make `DbMetadata` take parsed `SignedPayload`, not those from the `proto` module.
Note: `pkh_by_time` can contain stale entries through a race condition. Those should simply be ignored.