### PR TITLE
Allow querying range of metadata via `/metadata`

### DIFF
--- a/cashweb-registry/build.rs
+++ b/cashweb-registry/build.rs
@@ -1,6 +1,9 @@
 use std::io::Result;
 
 fn main() -> Result<()> {
-    prost_build::compile_protos(&["proto/registry.proto"], &["proto/"])?;
+    prost_build::compile_protos(
+        &["proto/registry.proto"],
+        &["proto/", "../cashweb-payload/proto/"],
+    )?;
     Ok(())
 }

--- a/cashweb-registry/proto/registry.proto
+++ b/cashweb-registry/proto/registry.proto
@@ -1,5 +1,6 @@
 syntax = "proto3";
 package cashweb.registry;
+import "payload.proto";
 
 // AddressEntry is an individual piece of structured data provided by wallet authors.
 message AddressEntry {
@@ -42,4 +43,18 @@ message Peers {
 message PutAddressMetadataResponse {
     // Transaction IDs of the burn txs.
     repeated bytes txid = 1;
+}
+
+// One entry of [`GetMetadataRangeResponse`].
+message GetMetadataRangeEntry {
+    // Address the [`SignedPayload`] is stored for.
+    string address = 1;
+    // Signed payload associated with the address.
+    cashweb.payload.SignedPayload signed_payload = 2;
+}
+
+// Response from getting a range of address metadata.
+message GetMetadataRangeResponse {
+    // Entries of this response.
+    repeated GetMetadataRangeEntry entries = 1;
 }

--- a/cashweb-registry/src/lib.rs
+++ b/cashweb-registry/src/lib.rs
@@ -14,6 +14,7 @@ pub mod registry;
 pub mod store;
 pub mod test_instance;
 
+use cashweb_payload::proto as payload;
 pub mod proto {
     //! Protobuf structs for SignedPayload.
     include!(concat!(env!("OUT_DIR"), "/cashweb.registry.rs"));

--- a/cashweb-registry/src/store/metadata.rs
+++ b/cashweb-registry/src/store/metadata.rs
@@ -50,7 +50,7 @@ impl<'a> DbMetadata<'a> {
         }
     }
 
-    /// Store a [`proto::SignedPayload`] in the db.
+    /// Store a [`cashweb_payload::proto::SignedPayload`] in the db.
     pub fn put(
         &self,
         pkh: &PubKeyHash,
@@ -81,7 +81,7 @@ impl<'a> DbMetadata<'a> {
         Ok(())
     }
 
-    /// Retrieve a [`proto::SignedPayload`] from the db.
+    /// Retrieve a [`cashweb_payload::proto::SignedPayload`] from the db.
     pub fn get(&self, pkh: &PubKeyHash) -> Result<Option<SignedPayload<proto::AddressMetadata>>> {
         use prost::Message;
         let serialized_entry = match self.db.get(self.cf_metadata, &pkh.to_storage_bytes())? {

--- a/cashweb-registry/src/store/pubkeyhash.rs
+++ b/cashweb-registry/src/store/pubkeyhash.rs
@@ -2,7 +2,9 @@
 
 use std::fmt::Display;
 
-use bitcoinsuite_core::{Bytes, Hashed, LotusAddress, Net, ScriptVariant, ShaRmd160, LOTUS_PREFIX};
+use bitcoinsuite_core::{
+    Bytes, Hashed, LotusAddress, Net, Script, ScriptVariant, ShaRmd160, LOTUS_PREFIX,
+};
 use bitcoinsuite_error::{ErrorMeta, Result, WrapErr};
 use thiserror::Error;
 
@@ -159,6 +161,17 @@ impl PubKeyHash {
                 PubKeyHash::new(PkhAlgorithm::Sha256Ripemd160, hash.as_slice().into())
             }
             variant => Err(UnsupportedScriptVariant(variant).into()),
+        }
+    }
+
+    /// Map the PubKeyHash to the corresponding Lotus address.
+    pub fn to_address(&self, net: Net) -> LotusAddress {
+        match self.algorithm {
+            PkhAlgorithm::Sha256Ripemd160 => LotusAddress::new(
+                LOTUS_PREFIX,
+                net,
+                Script::p2pkh(&ShaRmd160::from_slice(&self.hash).expect("Impossible hash length")),
+            ),
         }
     }
 


### PR DESCRIPTION
Add HTTP endpoint for querying a range of metadata by timestamp. Allows peers to sync their state.