### PR TITLE
Add `last_address` param to `/metadata`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,7 @@ jobs:
     - name: Build and install cargo make
       working-directory: ./cargo-make
       run: |
+        CARGO_TARGET_DIR=$(pwd)/../target cargo clean
         CARGO_TARGET_DIR=$(pwd)/../target cargo install --path . --target-dir $(pwd)/../target
       shell: bash
 


### PR DESCRIPTION
Skip entries that have the same timestamp as `start_timestamp` but where the pubkey hash is less than or equal to the given address' pubkey hash.

This allows specifying the largest timestamp returned from a previous call as `start_timestamp` with the corresponding address, to make sure all entries are retrieved once without duplicates.