### PR TITLE
Add `DbMetadata::get_latest`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,6 @@ jobs:
     - name: Build and install cargo make
       working-directory: ./cargo-make
       run: |
-        CARGO_TARGET_DIR=$(pwd)/../target cargo clean
         CARGO_TARGET_DIR=$(pwd)/../target cargo install --path . --target-dir $(pwd)/../target
       shell: bash
 


### PR DESCRIPTION
Returns the latest metadata entry, by timestamp and then public key hash.

Required for syncing metadata from scratch.