### PR TITLE
Rename `PutAddressMetadataResponse` to be more generic

### DIFF
--- a/cashweb-registry/proto/registry.proto
+++ b/cashweb-registry/proto/registry.proto
@@ -40,7 +40,7 @@ message Peers {
 }
 
 // Response after putting address metadata to the registry.
-message PutAddressMetadataResponse {
+message PutSignedPayloadResponse {
     // Transaction IDs of the burn txs.
     repeated bytes txid = 1;
 }

--- a/cashweb-registry/src/http/server.rs
+++ b/cashweb-registry/src/http/server.rs
@@ -114,7 +114,7 @@ async fn handle_put_registry(
     Protobuf(signed_metadata): Protobuf<cashweb_payload::proto::SignedPayload>,
     Extension(server): Extension<RegistryServer>,
     header_map: HeaderMap,
-) -> Result<Protobuf<proto::PutAddressMetadataResponse>, HttpRegistryError> {
+) -> Result<Protobuf<proto::PutSignedPayloadResponse>, HttpRegistryError> {
     let address = address.parse::<LotusAddress>().map_err(InvalidAddress)?;
     let request = PutMetadataRequest {
         address,
@@ -122,7 +122,7 @@ async fn handle_put_registry(
         signed_metadata,
     };
     let result = server.put_metadata(request).await?;
-    Ok(Protobuf(proto::PutAddressMetadataResponse {
+    Ok(Protobuf(proto::PutSignedPayloadResponse {
         txid: result
             .txids
             .into_iter()

--- a/cashweb-registry/tests/test_http_endpoint.rs
+++ b/cashweb-registry/tests/test_http_endpoint.rs
@@ -233,10 +233,10 @@ async fn test_registry_http() -> Result<()> {
         .await?;
     assert_eq!(response.status(), StatusCode::OK);
     let mut body = response.bytes().await?;
-    let broadcast_response = proto::PutAddressMetadataResponse::decode(&mut body)?;
+    let broadcast_response = proto::PutSignedPayloadResponse::decode(&mut body)?;
     assert_eq!(
         broadcast_response,
-        proto::PutAddressMetadataResponse {
+        proto::PutSignedPayloadResponse {
             txid: vec![lotus_txid(&tx).as_slice().to_vec()],
         },
     );
@@ -263,10 +263,10 @@ async fn test_registry_http() -> Result<()> {
         .await?;
     assert_eq!(response.status(), StatusCode::OK);
     let mut body = response.bytes().await?;
-    let broadcast_response = proto::PutAddressMetadataResponse::decode(&mut body)?;
+    let broadcast_response = proto::PutSignedPayloadResponse::decode(&mut body)?;
     assert_eq!(
         broadcast_response,
-        proto::PutAddressMetadataResponse {
+        proto::PutSignedPayloadResponse {
             txid: vec![lotus_txid(&tx).as_slice().to_vec()],
         },
     );

--- a/cashweb-registry/tests/test_p2p.rs
+++ b/cashweb-registry/tests/test_p2p.rs
@@ -121,10 +121,10 @@ async fn test_p2p() -> Result<()> {
     // Check request accepted
     assert_eq!(response.status(), StatusCode::OK);
     let mut body = response.bytes().await?;
-    let broadcast_response = proto::PutAddressMetadataResponse::decode(&mut body)?;
+    let broadcast_response = proto::PutSignedPayloadResponse::decode(&mut body)?;
     assert_eq!(
         broadcast_response,
-        proto::PutAddressMetadataResponse {
+        proto::PutSignedPayloadResponse {
             txid: vec![lotus_txid(&tx).as_slice().to_vec()],
         },
     );


### PR DESCRIPTION
This response can be used with the `/message` endpoint as well. Rename it in advance of using it.