### PR TITLE
Verifying commitments depend on the type of SignedPayload

### DIFF
--- a/cashweb-registry/src/registry.rs
+++ b/cashweb-registry/src/registry.rs
@@ -367,7 +367,7 @@ mod tests {
     use bitcoinsuite_test_utils_blockchain::{build_tx, setup_bitcoind_coins};
     use cashweb_payload::{
         payload::{ParseSignedPayloadError, SignatureScheme, SignedPayload},
-        verify::{build_commitment_script, ValidateSignedPayloadError},
+        verify::{build_commitment_script, ValidateSignedPayloadError, ADDRESS_METADATA_LOKAD_ID},
     };
     use pretty_assertions::assert_eq;
     use prost::Message;
@@ -437,7 +437,11 @@ mod tests {
             inputs: vec![],
             outputs: vec![TxOutput {
                 value: 1_000_000,
-                script: build_commitment_script(pubkey.array(), &payload_hash),
+                script: build_commitment_script(
+                    ADDRESS_METADATA_LOKAD_ID,
+                    pubkey.array(),
+                    &payload_hash,
+                ),
             }],
             lock_time: 0,
         };
@@ -602,7 +606,11 @@ mod tests {
                     TxBuilderOutput::Leftover(address.script().clone()),
                     TxBuilderOutput::Fixed(TxOutput {
                         value: burn_amount,
-                        script: build_commitment_script(pubkey.array(), &payload_hash),
+                        script: build_commitment_script(
+                            ADDRESS_METADATA_LOKAD_ID,
+                            pubkey.array(),
+                            &payload_hash,
+                        ),
                     }),
                 ],
                 lock_time: 0,
@@ -843,7 +851,11 @@ mod tests {
                 &anyone_script,
                 vec![TxOutput {
                     value: burn_amount,
-                    script: build_commitment_script(pubkey.array(), &payload_hash),
+                    script: build_commitment_script(
+                        ADDRESS_METADATA_LOKAD_ID,
+                        pubkey.array(),
+                        &payload_hash,
+                    ),
                 }],
             );
 

--- a/cashweb-registry/src/test_instance.rs
+++ b/cashweb-registry/src/test_instance.rs
@@ -10,7 +10,10 @@ use bitcoinsuite_core::{
 use bitcoinsuite_error::Result;
 use bitcoinsuite_test_utils::{is_free_tcp, pick_ports};
 use bitcoinsuite_test_utils_blockchain::build_tx;
-use cashweb_payload::{payload::SignatureScheme, verify::build_commitment_script};
+use cashweb_payload::{
+    payload::SignatureScheme,
+    verify::{build_commitment_script, ADDRESS_METADATA_LOKAD_ID},
+};
 use prost::Message;
 
 use crate::{
@@ -110,7 +113,11 @@ pub fn build_signed_metadata(
         redeem_script,
         vec![TxOutput {
             value: burn_amount,
-            script: build_commitment_script(pubkey.array(), &payload_hash),
+            script: build_commitment_script(
+                ADDRESS_METADATA_LOKAD_ID,
+                pubkey.array(),
+                &payload_hash,
+            ),
         }],
     );
 

--- a/cashweb-registry/tests/test_http_endpoint.rs
+++ b/cashweb-registry/tests/test_http_endpoint.rs
@@ -157,7 +157,11 @@ async fn test_registry_http() -> Result<()> {
             TxBuilderOutput::Leftover(address.script().clone()),
             TxBuilderOutput::Fixed(TxOutput {
                 value: burn_amount,
-                script: build_commitment_script(pubkey.array(), &payload_hash),
+                script: build_commitment_script(
+                    ADDRESS_METADATA_LOKAD_ID,
+                    pubkey.array(),
+                    &payload_hash,
+                ),
             }),
         ],
         lock_time: 0,

--- a/cashweb-registry/tests/test_http_endpoint.rs
+++ b/cashweb-registry/tests/test_http_endpoint.rs
@@ -11,7 +11,10 @@ use bitcoinsuite_error::Result;
 use bitcoinsuite_test_utils::bin_folder;
 use bitcoinsuite_test_utils_blockchain::setup_bitcoind_coins;
 use cashweb_http_utils::protobuf::CONTENT_TYPE_PROTOBUF;
-use cashweb_payload::{payload::SignatureScheme, verify::build_commitment_script};
+use cashweb_payload::{
+    payload::SignatureScheme,
+    verify::{build_commitment_script, ADDRESS_METADATA_LOKAD_ID},
+};
 use cashweb_registry::{proto, test_instance::RegistryTestInstance};
 use pretty_assertions::assert_eq;
 use prost::Message;


### PR DESCRIPTION
This commit makes it so the verification of the commitment can accept different commitment_ids so we can add topic support in a future commit.