### PR TITLE
Implement optional payloads if payload_hash is specified

### DIFF
--- a/cashweb-payload/src/verify.rs
+++ b/cashweb-payload/src/verify.rs
@@ -240,11 +240,11 @@ mod tests {
         )?;
 
         let mut signed_payload = SignedPayload {
-            payload: (),
+            payload: None,
             pubkey,
             sig: Bytes::new(),
             sig_scheme: SignatureScheme::Schnorr,
-            payload_raw,
+            payload_raw: Some(payload_raw),
             payload_hash: payload_hash.clone(),
             burn_amount: 0,
             burn_txs: vec![],

--- a/cashweb-registry/src/p2p/peers.rs
+++ b/cashweb-registry/src/p2p/peers.rs
@@ -216,6 +216,10 @@ impl Peers {
                 println!("Fetched {} entries from {}", entries.len(), peer.url());
             }
             for (address, signed_metadata) in entries {
+                if signed_metadata.payload().is_none() {
+                    continue;
+                }
+                let signed_payload = signed_metadata.payload().as_ref().unwrap();
                 is_all_empty = false;
                 let mut peer_state = peer.state.lock().await;
                 match params
@@ -236,7 +240,7 @@ impl Peers {
                         continue;
                     }
                 }
-                match signed_metadata.payload().timestamp.cmp(last_timestamp) {
+                match signed_payload.timestamp.cmp(last_timestamp) {
                     Ordering::Less => {}
                     Ordering::Equal => {
                         let last_pkh =
@@ -247,7 +251,7 @@ impl Peers {
                         }
                     }
                     Ordering::Greater => {
-                        *last_timestamp = signed_metadata.payload().timestamp;
+                        *last_timestamp = signed_payload.timestamp;
                         *last_address = address;
                     }
                 }

--- a/cashweb-registry/src/store/topics.rs
+++ b/cashweb-registry/src/store/topics.rs
@@ -72,7 +72,7 @@ impl<'a> DbTopics<'a> {
     /// Put a serialized `Message` to database.
     pub fn put_message(&self, timestamp: u64, message: &TopicPayload) -> Result<()> {
         let buf = message.to_proto().encode_to_vec();
-        let payload = message.payload();
+        let payload = message.payload().as_ref().ok_or(MissingPayload())?;
         let topic = payload.topic.clone();
 
         let split_topic = topic.split('.').collect::<Vec<_>>();


### PR DESCRIPTION
Payloads should be optional in signed messages if the `payload_hash` is provided. This allows
for updating the burn transactions on posts by other users.