### PR TITLE
Add support for updated votes on a topic

### DIFF
--- a/cashweb-registry/src/store/db.rs
+++ b/cashweb-registry/src/store/db.rs
@@ -15,7 +15,7 @@ pub(crate) const CF_METADATA: &str = "metadata";
 pub(crate) const CF_PKH_BY_TIME: &str = "pkh_by_time";
 pub(crate) const CF_MESSAGES: &str = "topic_messages";
 pub(crate) const CF_PAYLOADS: &str = "message_payloads";
-pub(crate) const CF_BURNS: &str = "topic_burn_txs";
+pub(crate) const CF_TOPIC_BURNS: &str = "topic_burn_txs";
 
 pub(crate) type CF = rocksdb::ColumnFamily;
 

--- a/cashweb-registry/src/store/db.rs
+++ b/cashweb-registry/src/store/db.rs
@@ -15,6 +15,7 @@ pub(crate) const CF_METADATA: &str = "metadata";
 pub(crate) const CF_PKH_BY_TIME: &str = "pkh_by_time";
 pub(crate) const CF_MESSAGES: &str = "topic_messages";
 pub(crate) const CF_PAYLOADS: &str = "message_payloads";
+pub(crate) const CF_BURNS: &str = "topic_burn_txs";
 
 pub(crate) type CF = rocksdb::ColumnFamily;
 

--- a/cashweb-registry/src/store/topics.rs
+++ b/cashweb-registry/src/store/topics.rs
@@ -4,7 +4,7 @@ use crate::{
     proto,
     store::db::{Db, CF, CF_MESSAGES, CF_PAYLOADS},
 };
-use bitcoinsuite_core::{Hashed, Sha256};
+use bitcoinsuite_core::{lotus_txid, Hashed, Sha256};
 use bitcoinsuite_error::{ErrorMeta, Result, WrapErr};
 use cashweb_payload::payload::SignedPayload;
 use prost::Message;
@@ -19,6 +19,7 @@ pub struct DbTopics<'a> {
     db: &'a Db,
     cf_messages: &'a CF,
     cf_payloads: &'a CF,
+    cf_burns: &'a CF,
 }
 
 /// Errors indicating some registry topic error.
@@ -56,22 +57,26 @@ pub enum DbTopicsError {
 }
 use self::DbTopicsError::*;
 
+use super::db::CF_BURNS;
+
 /// Allows access to registry topics.
 impl<'a> DbTopics<'a> {
     /// Create a new [`DbTopic`] instance.
     pub fn new(db: &'a Db) -> Self {
         let cf_messages = db.cf(CF_MESSAGES).unwrap();
         let cf_payloads = db.cf(CF_PAYLOADS).unwrap();
+        let cf_burns = db.cf(CF_BURNS).unwrap();
+
         DbTopics {
             db,
             cf_messages,
             cf_payloads,
+            cf_burns,
         }
     }
 
     /// Put a serialized `Message` to database.
     pub fn put_message(&self, timestamp: u64, message: &TopicPayload) -> Result<()> {
-        let buf = message.to_proto().encode_to_vec();
         let payload = message.payload().as_ref().ok_or(MissingPayload())?;
         let topic = payload.topic.clone();
 
@@ -82,25 +87,55 @@ impl<'a> DbTopics<'a> {
         if split_topic.iter().any(|segment| segment.is_empty()) {
             return Err(TopicInvalidSegments())?;
         }
-
         let payload_hash = message.payload_hash().as_slice().to_vec();
 
+        // Update existing record if we have one.
+        // TODO: needs a key-level lock on this.
+        let possibly_existing_message = self.get_message(&payload_hash);
+        let db = self.db.rocksdb();
+        let payload_buf = message.to_proto().encode_to_vec();
         let mut batch = rocksdb::WriteBatch::default();
 
-        batch.put_cf(self.cf_payloads, &payload_hash, &buf);
-
-        for idx in 0..split_topic.len() + 1 {
-            let base_topic_parts = split_topic[..idx].join(".");
-            let topic_digest = Sha256::digest(base_topic_parts.as_bytes().into())
-                .as_slice()
-                .to_vec();
-            let topical_key = [
-                &topic_digest,
-                timestamp.to_be_bytes().as_ref(),
+        let mut new_burns = vec![];
+        if possibly_existing_message.is_ok() {
+            let mut found_message = possibly_existing_message.unwrap();
+            new_burns.extend(found_message.add_burn_txs(message.txs()));
+            // Update existing key.
+            // TODO: Implement merging here instead of doing an update in this way as there may be a database race.
+            batch.put_cf(
+                self.cf_payloads,
                 &payload_hash,
-            ]
-            .concat();
-            batch.put_cf(self.cf_messages, &topical_key, &payload_hash);
+                &message.to_proto().encode_to_vec(),
+            );
+        } else {
+            new_burns.extend(message.txs());
+            //
+            batch.put_cf(self.cf_payloads, &payload_hash, &payload_buf);
+        }
+        // TODO: We need to only update the topics w/ timestamp iff the burn txns are not yet in there.
+        let buf = message.to_proto_without_payload().encode_to_vec();
+        for burn_tx in new_burns {
+            let tx_id = lotus_txid(burn_tx.tx().unhashed_tx()).to_vec_be();
+            // If we've already recorded an entry for this burn tx, don't record again.
+            if db.key_may_exist_cf(self.cf_burns, &tx_id) {
+                continue;
+            }
+            batch.put_cf(self.cf_burns, &tx_id, vec![]);
+
+            for idx in 0..split_topic.len() + 1 {
+                let base_topic_parts = split_topic[..idx].join(".");
+                let topic_digest = Sha256::digest(base_topic_parts.as_bytes().into())
+                    .as_slice()
+                    .to_vec();
+                let topical_key = [
+                    topic_digest.as_slice(),
+                    timestamp.to_be_bytes().as_ref(),
+                    tx_id.as_slice(),
+                ]
+                .concat();
+
+                batch.put_cf(self.cf_messages, &topical_key, &buf);
+            }
         }
         self.db.write_batch(batch)?;
         Ok(())
@@ -113,6 +148,7 @@ impl<'a> DbTopics<'a> {
 
         let payload_hash = message.payload_hash().as_slice().to_vec();
 
+        // TODO: This should really use a merge operation that combines the burn_outputs.
         self.db
             .rocksdb()
             .put_cf(self.cf_payloads, &payload_hash, &buf)?;
@@ -145,15 +181,15 @@ impl<'a> DbTopics<'a> {
             Err(_) => false,
         })
         .map(|item| {
-            let (_, payload_digest) = item?;
-            self.get_message(&payload_digest)
+            let (_, wrapper) = item?;
+            let proto = cashweb_payload::proto::SignedPayload::decode(&*wrapper)?;
+            TopicPayload::parse_proto(&proto).wrap_err(InvalidSignedPayloadInDb)
         })
         .collect()
     }
 
     /// Get a vector of messages starting at some unix timestamp.
     /// TODO: actually use this
-    #[allow(dead_code)]
     pub fn get_messages(&self, topic: &str, from: i64) -> Result<Vec<TopicPayload>> {
         self.get_messages_to(topic, from, i64::MAX)
     }
@@ -170,10 +206,26 @@ impl<'a> DbTopics<'a> {
         Ok(TopicPayload::parse_proto(&proto).wrap_err(InvalidSignedPayloadInDb)?)
     }
 
+    /// Get a specific message by payload hash.
+    pub fn does_message_exist(&self, payload_digest: &[u8]) -> bool {
+        self.db
+            .rocksdb()
+            .key_may_exist_cf(self.cf_payloads, payload_digest)
+    }
+
     pub(crate) fn add_cfs(columns: &mut Vec<ColumnFamilyDescriptor>) {
-        let options = rocksdb::Options::default();
-        columns.push(ColumnFamilyDescriptor::new(CF_MESSAGES, options.clone()));
-        columns.push(ColumnFamilyDescriptor::new(CF_PAYLOADS, options));
+        columns.push(ColumnFamilyDescriptor::new(
+            CF_MESSAGES,
+            rocksdb::Options::default(),
+        ));
+        columns.push(ColumnFamilyDescriptor::new(
+            CF_PAYLOADS,
+            rocksdb::Options::default(),
+        ));
+        columns.push(ColumnFamilyDescriptor::new(
+            CF_BURNS,
+            rocksdb::Options::default(),
+        ));
     }
 }
 
@@ -273,31 +325,53 @@ mod tests {
         // Get from database
         let data_wrapper_out = database.get_messages("foo.bar.bob", 0)?;
         assert_eq!(data_wrapper_out.len(), 1);
-        assert_eq!(message_one, data_wrapper_out[0]);
+        let full_wrapper_out =
+            database.get_message(data_wrapper_out[0].payload_hash().as_slice())?;
+
+        assert_eq!(message_one, full_wrapper_out);
 
         // Get from database
         let data_wrapper_out = database.get_messages("foo", 0)?;
         assert_eq!(data_wrapper_out.len(), 1);
-        assert_eq!(message_one, data_wrapper_out[0]);
+        // Ensure we're storing the payload correctly.
+        assert_eq!(
+            message_one.payload_hash(),
+            data_wrapper_out[0].payload_hash()
+        );
 
         // Put to database
-        database.put_message(1, &message_two)?;
+        database.put_message(2, &message_two)?;
 
         // Get from database and ensure original topic wasn't changed
         let data_wrapper_out_two = database.get_messages("foo.bar.bob", 0)?;
         assert_eq!(data_wrapper_out_two.len(), 1);
-        assert_eq!(message_one, data_wrapper_out_two[0]);
+        assert_eq!(
+            message_one.payload_hash(),
+            data_wrapper_out_two[0].payload_hash()
+        );
 
         // Get from database
         let data_wrapper_three = database.get_messages("foo", 0)?;
         assert_eq!(data_wrapper_three.len(), 2);
-        assert_eq!(message_one, data_wrapper_three[0]);
-        assert_eq!(message_two, data_wrapper_three[1]);
+        assert_eq!(
+            message_one.payload_hash(),
+            data_wrapper_three[0].payload_hash()
+        );
+        assert_eq!(
+            message_two.payload_hash(),
+            data_wrapper_three[1].payload_hash()
+        );
 
         let data_wrapper_four = database.get_messages("", 0)?;
         assert_eq!(data_wrapper_four.len(), 2);
-        assert_eq!(message_one, data_wrapper_four[0]);
-        assert_eq!(message_two, data_wrapper_four[1]);
+        assert_eq!(
+            message_one.payload_hash(),
+            data_wrapper_four[0].payload_hash()
+        );
+        assert_eq!(
+            message_two.payload_hash(),
+            data_wrapper_four[1].payload_hash()
+        );
 
         // Destroy database
         Ok(())


### PR DESCRIPTION
Currently, there's no notification on a topic that a vote occured on an existing message. This commit adds support for tracking those state updates in the topic_cf. That will enable Stamp to properly update users who have already downloaded messages as to the fact that a post's votes were updated.