### PR TITLE
Add impl Drop for RegistryTestInstance

### DIFF
--- a/cashweb-registry/src/test_instance.rs
+++ b/cashweb-registry/src/test_instance.rs
@@ -94,6 +94,11 @@ impl RegistryTestInstance {
     }
 }
 
+impl Drop for RegistryTestInstance {
+    fn drop(&mut self) {
+        self.bitcoind.cleanup().ok();
+    }
+}
 /// Build a [`cashweb_payload::proto::SignedPayload`] for testing.
 pub fn build_signed_metadata(
     seckey: &SecKey,


### PR DESCRIPTION
Add Drop impl for RegistryTestInstance so that if a test ends prematurely the node is still cleaned up.