### PR TITLE
[metadata] Move pubkey commitment out of burn transaction

### DIFF
--- a/cashweb-registry/proto/registry.proto
+++ b/cashweb-registry/proto/registry.proto
@@ -16,15 +16,22 @@ message AddressEntry {
 // AddressMetadata is the user-specified data that is covered by the users
 // signature.
 message AddressMetadata {
+    // Repeat pubkey key here so there is a commitment to the key in the signed
+    // payload. We want the overall format for SignedPayloads to be able to be
+    // verified and checked against burns without particular details of this
+    // payload needed. Repeating it here ensures that the "SignedPayload" layer
+    // can be handled independently of payload data, and that this payload data
+    // isn't reusable for other keys.
+    bytes pubkey = 1;
     // Timestamp allows servers to determine which version of the data is the most
     // recent. Given in milliseconds.
-    int64 timestamp = 1;
+    int64 timestamp = 2;
     // TTL tells us how long this entry should exist before being considered
     // invalid. Given in milliseconds.
-    int64 ttl = 2;
+    int64 ttl = 3;
     // User specified data. Presumably some conventional data determined by
     // wallet authors.
-    repeated AddressEntry entries = 3;
+    repeated AddressEntry entries = 4;
 }
 
 // Peer represents a single peer.

--- a/cashweb-registry/src/p2p/peer.rs
+++ b/cashweb-registry/src/p2p/peer.rs
@@ -559,6 +559,7 @@ mod tests {
                             sig: vec![],
                             sig_scheme: SignatureScheme::Ecdsa as i32,
                             payload: proto::AddressMetadata {
+                                pubkey: vec![0; 33],
                                 timestamp: 1234,
                                 ttl: 10,
                                 entries: vec![],
@@ -694,6 +695,7 @@ mod tests {
                         sig: vec![],
                         sig_scheme: SignatureScheme::Ecdsa as i32,
                         payload: proto::AddressMetadata {
+                            pubkey: vec![0; 33],
                             timestamp: 1234,
                             ttl: 10,
                             entries: vec![],

--- a/cashweb-registry/src/store/metadata.rs
+++ b/cashweb-registry/src/store/metadata.rs
@@ -183,6 +183,7 @@ mod tests {
         assert_eq!(db.metadata().get_latest()?, None);
 
         let mut address_metadata = proto::AddressMetadata {
+            pubkey: vec![2; 33],
             timestamp: 1234,
             ttl: 10,
             entries: vec![],
@@ -306,6 +307,7 @@ mod tests {
         for i in 0u8..50 {
             let pkh = PubKeyHash::new(PkhAlgorithm::Sha256Ripemd160, [i / 2; 20].into())?;
             let address_metadata = proto::AddressMetadata {
+                pubkey: vec![2; 33],
                 timestamp: 1000 + i as i64,
                 ttl: 10,
                 entries: vec![],

--- a/cashweb-registry/src/test_instance.rs
+++ b/cashweb-registry/src/test_instance.rs
@@ -118,11 +118,7 @@ pub fn build_signed_metadata(
         redeem_script,
         vec![TxOutput {
             value: burn_amount,
-            script: build_commitment_script(
-                ADDRESS_METADATA_LOKAD_ID,
-                pubkey.array(),
-                &payload_hash,
-            ),
+            script: build_commitment_script(ADDRESS_METADATA_LOKAD_ID, &payload_hash),
         }],
     );
 

--- a/cashweb-registry/tests/test_http_endpoint.rs
+++ b/cashweb-registry/tests/test_http_endpoint.rs
@@ -132,6 +132,7 @@ async fn test_registry_http() -> Result<()> {
 
     // Build valid request
     let address_metadata = proto::AddressMetadata {
+        pubkey: pubkey.array().to_vec(),
         timestamp: 1234,
         ttl: 10,
         entries: vec![],
@@ -162,11 +163,7 @@ async fn test_registry_http() -> Result<()> {
             TxBuilderOutput::Leftover(address.script().clone()),
             TxBuilderOutput::Fixed(TxOutput {
                 value: burn_amount,
-                script: build_commitment_script(
-                    ADDRESS_METADATA_LOKAD_ID,
-                    pubkey.array(),
-                    &payload_hash,
-                ),
+                script: build_commitment_script(ADDRESS_METADATA_LOKAD_ID, &payload_hash),
             }),
         ],
         lock_time: 0,
@@ -642,11 +639,7 @@ fn build_signed_message<T: prost::Message + Default>(
             TxBuilderOutput::Leftover(address.script().clone()),
             TxBuilderOutput::Fixed(TxOutput {
                 value: burn_amount,
-                script: build_commitment_script(
-                    BROADCAST_MESSAGE_LOKAD_ID,
-                    pubkey.array(),
-                    &payload_hash,
-                ),
+                script: build_commitment_script(BROADCAST_MESSAGE_LOKAD_ID, &payload_hash),
             }),
         ],
         lock_time: 0,

--- a/cashweb-registry/tests/test_imd.rs
+++ b/cashweb-registry/tests/test_imd.rs
@@ -95,6 +95,7 @@ async fn test_imd() -> Result<()> {
         for (instance_idx, instance) in instances.iter().enumerate().take(num_instances - 1) {
             // Build valid address metadata
             let address_metadata = proto::AddressMetadata {
+                pubkey: pubkey.array().to_vec(),
                 timestamp: 1000 + instance_idx as i64,
                 ttl: 10,
                 entries: vec![],

--- a/cashweb-registry/tests/test_p2p.rs
+++ b/cashweb-registry/tests/test_p2p.rs
@@ -102,6 +102,7 @@ async fn test_p2p() -> Result<()> {
         &mut utxos,
         &anyone_script,
         proto::AddressMetadata {
+            pubkey: pubkey.array().to_vec(),
             timestamp: 1234,
             ttl: 10,
             entries: vec![],


### PR DESCRIPTION
Currently, for burn transactions are expected to be a hash of the combination of the pubkey and the payload hash. However, this has consequences for the topic posts which need to have a commitment to their hash directly on the blockchain, and voting transactions do not necessarily need to sign the payloads.

On the other hand, for address metadata if the serialized payload does not commit to the pubkey then the burn transactions could be reusable to input many addresses into the registry server.

This commit does two things:

1. Repeat the pubkey in the AddressMetadata so the hash of the serialized protobuf will commit to the pubkey.
2. Remove the need to commit to the pubkey in the OP_RETURN commitment that burns some Lotus.